### PR TITLE
Update setup.sh to use the latest Lua and LuaRocks from source

### DIFF
--- a/lua/setup.sh
+++ b/lua/setup.sh
@@ -33,7 +33,7 @@ install_lua() {
       
       # Download and install latest LuaRocks from source
       cd /tmp
-      curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+      curl -L -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
       tar zxpf "luarocks-3.11.1.tar.gz"
       cd "luarocks-3.11.1"
       ./configure && make && sudo make install
@@ -66,7 +66,7 @@ install_lua() {
     
     # Download and install latest LuaRocks from source
     cd /tmp
-    curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+    curl -L -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
     tar zxpf "luarocks-3.11.1.tar.gz"
     cd "luarocks-3.11.1"
     ./configure --with-lua-include=/usr/local/include && make && sudo make install
@@ -101,7 +101,7 @@ else
     
     # Download and install only LuaRocks
     cd /tmp
-    curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+    curl -L -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
     tar zxpf "luarocks-3.11.1.tar.gz"
     cd "luarocks-3.11.1"
     ./configure && make && sudo make install

--- a/lua/setup.sh
+++ b/lua/setup.sh
@@ -18,9 +18,26 @@ install_lua() {
     fi
     brew install lua luarocks
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    echo "Installing Lua environment on Linux..."
+    echo "Installing latest Lua environment on Linux..."
     sudo apt-get update
-    sudo apt-get install -y lua5.3 liblua5.3-dev luarocks
+    sudo apt-get install -y build-essential libreadline-dev
+    
+    # Download and install latest Lua from source
+    cd /tmp
+    curl -R -O "https://www.lua.org/ftp/lua-5.4.7.tar.gz"  # Current latest stable
+    tar xvfz "lua-5.4.7.tar.gz"
+    cd "lua-5.4.7"
+    make linux
+    sudo make install
+    
+    # Download and install latest LuaRocks from source
+    cd /tmp
+    curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+    tar xvfz "luarocks-3.11.1.tar.gz"
+    cd "luarocks-3.11.1"
+    ./configure --with-lua-include=/usr/local/include
+    make
+    sudo make install
   else
     echo "Unsupported OS: $OSTYPE"
     exit 1

--- a/lua/setup.sh
+++ b/lua/setup.sh
@@ -12,32 +12,64 @@ check_sudo() {
 install_lua() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Installing Lua environment on macOS..."
-    if ! command -v brew >/dev/null; then
-      echo "Homebrew not found. Please install Homebrew first: https://brew.sh/"
-      exit 1
+    if command -v brew >/dev/null; then
+      echo "Using Homebrew to install Lua and LuaRocks..."
+      brew install lua luarocks
+    else
+      echo "Homebrew not found. Installing from source..."
+      # Install dependencies (Xcode command line tools should provide what we need)
+      if ! command -v xcode-select -p >/dev/null; then
+        echo "Installing Xcode Command Line Tools..."
+        xcode-select --install
+      fi
+      
+      # Download and install latest Lua from source
+      cd /tmp
+      curl -L -R -O "https://www.lua.org/ftp/lua-5.4.7.tar.gz"
+      tar zxf "lua-5.4.7.tar.gz"
+      cd "lua-5.4.7"
+      make macosx test
+      sudo make install
+      
+      # Download and install latest LuaRocks from source
+      cd /tmp
+      curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+      tar zxpf "luarocks-3.11.1.tar.gz"
+      cd "luarocks-3.11.1"
+      ./configure && make && sudo make install
     fi
-    brew install lua luarocks
   elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     echo "Installing latest Lua environment on Linux..."
-    sudo apt-get update
-    sudo apt-get install -y build-essential libreadline-dev
+    
+    # Check for package manager and install build dependencies
+    if command -v apt-get >/dev/null; then
+      echo "Debian-based system detected"
+      sudo apt-get update
+      sudo apt-get install -y build-essential libreadline-dev
+    elif command -v dnf >/dev/null; then
+      echo "Fedora/RHEL-based system detected"
+      sudo dnf install -y make gcc readline-devel
+    elif command -v pacman >/dev/null; then
+      echo "Arch-based system detected"
+      sudo pacman -Sy base-devel readline
+    else
+      echo "Unknown Linux distribution. Ensure you have build tools (gcc, make) and readline development libraries installed."
+    fi
     
     # Download and install latest Lua from source
     cd /tmp
-    curl -R -O "https://www.lua.org/ftp/lua-5.4.7.tar.gz"  # Current latest stable
-    tar xvfz "lua-5.4.7.tar.gz"
+    curl -L -R -O "https://www.lua.org/ftp/lua-5.4.7.tar.gz"  # Current latest stable
+    tar zxf "lua-5.4.7.tar.gz"
     cd "lua-5.4.7"
-    make linux
+    make all test
     sudo make install
     
     # Download and install latest LuaRocks from source
     cd /tmp
     curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
-    tar xvfz "luarocks-3.11.1.tar.gz"
+    tar zxpf "luarocks-3.11.1.tar.gz"
     cd "luarocks-3.11.1"
-    ./configure --with-lua-include=/usr/local/include
-    make
-    sudo make install
+    ./configure --with-lua-include=/usr/local/include && make && sudo make install
   else
     echo "Unsupported OS: $OSTYPE"
     exit 1
@@ -56,18 +88,26 @@ install_dependencies() {
 # Main execution
 check_sudo
 
+# Install Lua if not found
 if ! command -v lua >/dev/null; then
-  echo "Lua not found, installing..."
+  echo "Lua not found, installing both Lua and LuaRocks..."
   install_lua
 else
   echo "Lua found: $(lua -v)"
-fi
-
-if ! command -v luarocks >/dev/null; then
-  echo "LuaRocks not found, installing..."
-  install_lua
-else
-  echo "LuaRocks found: $(luarocks --version)"
+  
+  # Only install LuaRocks if not found
+  if ! command -v luarocks >/dev/null; then
+    echo "LuaRocks not found, installing only LuaRocks..."
+    
+    # Download and install only LuaRocks
+    cd /tmp
+    curl -R -O "https://luarocks.org/releases/luarocks-3.11.1.tar.gz"
+    tar zxpf "luarocks-3.11.1.tar.gz"
+    cd "luarocks-3.11.1"
+    ./configure && make && sudo make install
+  else
+    echo "LuaRocks found: $(luarocks --version)"
+  fi
 fi
 
 install_dependencies


### PR DESCRIPTION
### Changes
- Install latest Lua (5.4.7) from source instead of apt packages
- Install LuaRocks from source (3.11.1) for cross-platform compatibility
- Add necessary build dependencies
- Improve tar extraction with better flags
- Add support for multiple Linux distributions (Debian, Fedora/RHEL, Arch)
- Add fallback installation for macOS without Homebrew
- Implement smarter detection to only install missing components

This change makes the setup more portable and consistent with our CI pipeline.

### References
- https://lua.org/download.html
- https://luarocks.org/#quick-start