### PR TITLE
Fix client test: add missing makeContext to SDK utility

### DIFF
--- a/ts/test/sdk.ts
+++ b/ts/test/sdk.ts
@@ -11,6 +11,7 @@ class SDK {
     this.#utility = {
       struct: new StructUtility(),
       contextify: (ctxmap: any) => ctxmap,
+      makeContext: (ctxmap: any) => ctxmap,
       check: (ctx: any) => {
         return {
           zed: 'ZED' +


### PR DESCRIPTION
The test runner expects utility.makeContext but the SDK test helper only provided contextify. Added makeContext as identity function.

https://claude.ai/code/session_01QkN2u1cRavoxb7UebdMcDr