### PR TITLE
Add comprehensive documentation for struct library across all language ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,341 @@
-# struct
+# Voxgig Struct
 
-Uniform data structure manipulations in multiple languages.
+> Uniform JSON-shaped data structure manipulations, in many languages.
+
+`struct` is the data manipulation primitive used inside the Voxgig
+SDKs.  Every Voxgig SDK -- whatever its host language -- needs to look
+up values inside nested JSON, merge configurations, transform data
+between shapes, and validate that incoming data matches an expected
+shape.  Rewriting that work for each language drifts: behaviours
+diverge, edge cases get patched in one place but not another, and the
+semantics of "the same" call become subtly different.
+
+`struct` solves that by defining one canonical API, in one canonical
+implementation (TypeScript), and porting it to every language a
+Voxgig SDK runs in.  The same names, the same arguments, the same
+return values, and the same JSON-driven test corpus run against every
+port.  When you call `getpath('a.b.c', store)` in Python, Go, PHP, or
+Lua, you get the same answer.
 
 
+## Documentation map (Diataxis)
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework, which
+splits documentation into four quadrants by purpose:
+
+| Quadrant      | Purpose                | Where to find it                                                  |
+|---------------|------------------------|-------------------------------------------------------------------|
+| Tutorial      | Learning by doing      | [Quick start](#quick-start) below + each language's `DOCS.md`     |
+| How-to guides | Solving a task         | [Common recipes](#common-recipes) below + each language's docs    |
+| Reference     | Looking things up      | [API reference](#language-neutral-api-reference) below + per-lang |
+| Explanation   | Understanding the why  | [Motivation](#motivation) and [Concepts](#concepts) below         |
+
+Per-language docs live next to each implementation:
+
+| Language   | Status     | Docs                              |
+|------------|------------|-----------------------------------|
+| TypeScript | Canonical  | [`ts/DOCS.md`](./ts/DOCS.md)      |
+| JavaScript | Complete   | [`js/DOCS.md`](./js/DOCS.md)      |
+| Python     | Complete   | [`py/DOCS.md`](./py/DOCS.md)      |
+| Go         | Complete   | [`go/DOCS.md`](./go/DOCS.md)      |
+| PHP        | Complete   | [`php/DOCS.md`](./php/DOCS.md)    |
+| Ruby       | Complete   | [`rb/DOCS.md`](./rb/DOCS.md)      |
+| Lua        | Complete   | [`lua/DOCS.md`](./lua/DOCS.md)    |
+| C#         | In progress| [`cs/DOCS.md`](./cs/DOCS.md)      |
+| Zig        | In progress| [`zig/DOCS.md`](./zig/DOCS.md)    |
+| Java       | Partial    | [`java/DOCS.md`](./java/DOCS.md)  |
+| C++        | Partial    | [`cpp/DOCS.md`](./cpp/DOCS.md)    |
+
+The cross-language parity matrix lives in [`REPORT.md`](./REPORT.md).
+
+
+## Motivation
+
+Voxgig SDKs work with structured data: configuration trees, API
+request and response payloads, validation specs, transform recipes.
+These are JSON-shaped: nested maps and lists of scalars.  The same
+operations come up over and over:
+
+- "Give me the value at path `service.db.host`."
+- "Merge these three config maps, last one wins, but deep-merge maps."
+- "Walk this tree and replace any `null` value with a default."
+- "Take this template, and populate it from this data store."
+- "Check that this incoming record matches the expected shape."
+
+The naive answer is "use the host language's stdlib".  But:
+
+- The host language may not have a deep merge.  Or its deep merge
+  may have different rules than the next language's deep merge.
+- "Get a value at a path" is one line in JavaScript and ten in C++.
+- The semantics of `null` versus "absent" versus "empty" differ
+  between languages, between JSON parsers, and between developers on
+  the same team.
+- Once you have transforms and validation, you really do not want to
+  reimplement them per language.
+
+`struct` is the answer: one API, one set of semantics, one JSON test
+corpus, ported faithfully to every language Voxgig SDKs support.  An
+SDK can rely on the same primitive operations everywhere.  A bug fix
+in the canonical TypeScript flows through to every other port.
+
+The shared test corpus (`build/test/*.jsonic`) is the contract.  Any
+implementation passes only if it matches the canonical answers
+case-for-case.
+
+
+## Concepts
+
+A few terms recur throughout the API.
+
+- **Node**: a map (object) or list (array).  Anything that can have
+  children.
+- **Key**: a non-empty string (for maps) or an integer index (for
+  lists).
+- **Path**: a sequence of keys, written as a dotted string
+  (`'a.b.0.c'`) or an array (`['a','b',0,'c']`).
+- **Store**: the source data for an injection or path lookup.
+- **Spec**: a by-example data structure that drives `transform` and
+  `validate`.  The spec mirrors the desired output shape.
+- **Injection**: substituting backtick-quoted references inside a
+  spec with values pulled from a store, e.g. ``` `a.b` ``` becomes the
+  value at path `a.b` in the store.
+- **Sentinel**: a special marker value with no in-band JSON
+  representation.  `SKIP` means "don't write this key", `DELETE`
+  means "remove this key".
+
+By-example design: the shape of the output is described by data that
+*looks like* the output.  A transform spec for `{name, age}` is itself
+a map with keys `name` and `age`.  A validate spec is the same shape
+as the data it accepts, with type tokens (e.g. ``` `$STRING` ```) at
+the leaves.
+
+
+## Quick start
+
+Pick your language's `DOCS.md` for installation instructions.  Once
+installed, the calls below all mean the same thing.
+
+### Look up a value at a path
+
+JavaScript / TypeScript:
+
+```js
+const { getpath } = require('@voxgig/struct')
+getpath('db.host', { db: { host: 'localhost', port: 5432 } })
+// => 'localhost'
+```
+
+Python:
+
+```python
+from voxgig_struct import getpath
+getpath('db.host', {'db': {'host': 'localhost', 'port': 5432}})
+# => 'localhost'
+```
+
+Go:
+
+```go
+voxgigstruct.GetPath("db.host", map[string]any{
+    "db": map[string]any{"host": "localhost", "port": 5432},
+})
+// => "localhost"
+```
+
+### Merge a chain of maps
+
+```js
+merge([
+  { a: 1, b: 2, x: { y: 5, z: 6 } },
+  { b: 3,       x: { y: 7 }       },
+])
+// => { a: 1, b: 3, x: { y: 7, z: 6 } }
+```
+
+Last input wins for scalars; maps deep-merge; lists are merged by
+index.
+
+### Transform by example
+
+```js
+transform(
+  { user: { first: 'Ada', last: 'Lovelace' }, age: 36 },
+  { name: '`user.first`', surname: '`user.last`', years: '`age`' }
+)
+// => { name: 'Ada', surname: 'Lovelace', years: 36 }
+```
+
+### Validate by example
+
+```js
+validate(
+  { name: 'Ada', age: 36 },
+  { name: '`$STRING`', age: '`$INTEGER`' }
+)
+// => { name: 'Ada', age: 36 }   // ok
+```
+
+### Walk a tree
+
+```js
+walk(tree, (key, val, parent, path) => {
+  return val === null ? 'DEFAULT' : val
+})
+```
+
+
+## Common recipes
+
+These map directly to the per-language API.  Substitute the function
+names that match your language's casing convention.
+
+| Goal                                       | Function                       |
+|--------------------------------------------|--------------------------------|
+| Read a deep value, with a default          | `getpath`, `getprop`, `getdef` |
+| Set a deep value, creating intermediate    | `setpath`                      |
+| Test a value's shape                       | `isnode`, `ismap`, `islist`, `iskey`, `isempty`, `isfunc` |
+| Get a type bitcode for a value             | `typify`                       |
+| Get a human type name                      | `typename`                     |
+| Sorted keys of a node                      | `keysof`                       |
+| Iterate `[key, value]` pairs               | `items`                        |
+| Deep copy                                  | `clone`                        |
+| Deep merge a list of maps                  | `merge`                        |
+| Walk a tree applying a function            | `walk`                         |
+| Slice / pad / flatten / filter             | `slice`, `pad`, `flatten`, `filter` |
+| Substitute references in a spec            | `inject`                       |
+| Build an output by example                 | `transform`                    |
+| Check a value against a shape              | `validate`                     |
+| Pick records out of a node by query        | `select`                       |
+| Build a JSON string                        | `jsonify`, `stringify`         |
+| Escape for regex / URL                     | `escre`, `escurl`              |
+| Join URL parts                             | `join`                         |
+
+
+## Language-neutral API reference
+
+This is the canonical API surface, defined in TypeScript at
+[`ts/src/StructUtility.ts`](./ts/src/StructUtility.ts).  Every port
+exposes equivalents.  The casing varies by language convention
+(`getpath` in JS/Py/Lua/Rb/PHP; `GetPath` in Go/C#; `getPath` in
+Java).
+
+### Minor utilities (25)
+
+```
+typename(t)                            -> string
+getdef(val, alt)                       -> any
+isnode(val) / ismap(val) / islist(val) -> bool
+iskey(key) / isempty(val) / isfunc(val)-> bool
+size(val)                              -> int
+slice(val, start?, end?, mutate?)      -> any
+pad(str, width?, char?)                -> string
+typify(val)                            -> int (bitfield)
+getelem(list, key, alt?)               -> any
+getprop(node, key, alt?)               -> any
+strkey(key)                            -> string
+keysof(node)                           -> string[]
+haskey(node, key)                      -> bool
+items(node)                            -> [key, val][]
+flatten(list, depth?)                  -> list
+filter(node, predicate)                -> list
+escre(s) / escurl(s)                   -> string
+join(arr, sep?, urlmode?)              -> string
+jsonify(val, flags?)                   -> string
+stringify(val, maxlen?)                -> string
+pathify(val, from?, to?)               -> string
+clone(val)                             -> any
+delprop(parent, key)                   -> parent
+setprop(parent, key, val)              -> parent
+```
+
+### Major utilities (8)
+
+```
+walk(node, apply, before?, after?, maxdepth?) -> node
+merge(list, maxdepth?)                        -> any
+setpath(store, path, val)                     -> store
+getpath(path, store)                          -> any
+inject(val, store, modify?)                   -> any
+transform(data, spec, extra?, modify?)        -> any
+validate(data, spec, extra?, collecterrs?)    -> any  (throws or collects on mismatch)
+select(query, obj)                            -> match[]
+```
+
+### Builders (2)
+
+```
+jm(...)   // build a map (JSON object) from key/value args
+jt(...)   // build a list (JSON tuple/array) from args
+```
+
+### Sentinels and constants
+
+```
+SKIP, DELETE                              // sentinel markers
+T_any, T_noval, T_boolean, T_decimal,
+T_integer, T_number, T_string, T_function,
+T_symbol, T_null, T_list, T_map,
+T_instance, T_scalar, T_node              // 15 type bit-flags
+M_KEYPRE, M_KEYPOST, M_VAL                // walk/inject phase tags
+MODENAME                                  // human name table for modes
+```
+
+### Transform commands (used inside spec strings)
+
+```
+$DELETE  $COPY  $KEY  $META  $ANNO
+$MERGE   $EACH  $PACK  $REF   $FORMAT  $APPLY
+```
+
+### Validate checkers (used inside spec strings)
+
+```
+$MAP  $LIST  $STRING  $NUMBER  $INTEGER  $DECIMAL  $BOOLEAN
+$NULL $NIL   $FUNCTION $INSTANCE $ANY $CHILD $ONE $EXACT
+```
+
+
+## Design notes
+
+- **By-example over DSL.**  A transform/validate spec looks like the
+  output it describes.  No second language to learn.
+- **Tolerant of "absent".**  Functions return a defined alternative
+  (`alt`) rather than throwing on missing keys.  Each language port
+  handles its own undefined/null distinction; see per-language docs.
+- **Lists are mutable and reference-stable.**  In languages where
+  this is not native (Go, PHP), the port introduces a wrapper
+  (`ListRef`).
+- **JSON null is not undefined.**  Most JSON parsers conflate them;
+  `struct` distinguishes them.  The shared test corpus uses the
+  string `"__NULL__"` to stand in for JSON null where the test
+  language can't represent it directly.
+- **The TypeScript implementation is canonical.**  Disagreement
+  between a port and the test corpus is a port bug.
+
+
+## Repository layout
+
+```
+.
+├── README.md         # this file
+├── REPORT.md         # cross-language parity matrix
+├── build/test/       # shared JSON test corpus (.jsonic)
+├── ts/  js/  py/     # canonical + JS-family ports
+├── go/  rb/  php/    # other complete ports
+├── lua/ cs/ zig/
+├── java/ cpp/        # partial ports
+└── LICENSE
+```
+
+Each language directory contains:
+
+- the implementation source,
+- a test runner that consumes `build/test/*.jsonic`,
+- a `Makefile` with at minimum a `make test` target,
+- a `DOCS.md` with the per-language guide,
+- `NOTES.md` and `REVIEW.md` with implementation history.
+
+
+## License
+
+MIT.  See [`LICENSE`](./LICENSE).

--- a/cpp/DOCS.md
+++ b/cpp/DOCS.md
@@ -1,0 +1,169 @@
+# Struct for C++
+
+> C++ port of the canonical TypeScript implementation.
+> **Status: partial.**  Basic type/property utilities only; major
+> subsystems (`inject`, `transform`, `validate`, `select`,
+> `getpath`, `setpath`) are not yet implemented.  Use the canonical
+> TS or one of the complete ports for production work.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).  For the parity matrix see
+[`../REPORT.md`](../REPORT.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first call
+
+### Build
+
+Inside the monorepo:
+
+```bash
+cd cpp
+make build         # builds with Catch2
+make test          # runs Catch2 tests
+```
+
+The library is header-only at
+[`src/voxgig_struct.hpp`](./src/voxgig_struct.hpp), namespace
+`VoxgigStruct`.  It depends on
+[nlohmann/json](https://github.com/nlohmann/json) for the JSON
+container.
+
+### A first call
+
+```cpp
+#include "voxgig_struct.hpp"
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+using namespace VoxgigStruct;
+
+int main() {
+    json store = { {"db", {{"host", "localhost"}}} };
+
+    args_container args = { store, json("db") };
+    json db = getprop(std::move(args));
+    // db == { "host": "localhost" }
+
+    return 0;
+}
+```
+
+
+## How-to recipes (current scope)
+
+The currently-implemented functions are:
+
+```
+typename_of, typify, isnode, ismap, islist, iskey, isempty, isfunc,
+getprop, setprop, keysof, haskey, items, escre, escurl, joinurl,
+stringify, clone, walk, merge (partial)
+```
+
+### Test a value's shape
+
+```cpp
+isnode(value);
+ismap(value);
+islist(value);
+```
+
+### Read a single property
+
+```cpp
+args_container args = { node, json("key") };
+json v = getprop(std::move(args));
+```
+
+### Walk
+
+```cpp
+walk(tree, [](const json& key, const json& val,
+              const json& parent, const json& path) {
+    return val.is_null() ? json("DEFAULT") : val;
+});
+```
+
+
+## Reference
+
+Source: [`src/voxgig_struct.hpp`](./src/voxgig_struct.hpp).
+Namespace `VoxgigStruct`.
+
+### Constants
+
+All 15 type bit-flags as `constexpr int`:
+
+```cpp
+VoxgigStruct::T_any
+VoxgigStruct::T_noval
+VoxgigStruct::T_boolean
+// ... etc
+```
+
+Sentinels (`SKIP`, `DELETE`) and mode constants are not yet defined.
+
+### Calling convention
+
+Most functions accept `args_container&&` (a `std::vector<json>`)
+rather than typed parameters.  This is a porting shortcut that
+mirrors the variadic shape of the canonical functions; it will be
+replaced with type-safe signatures.
+
+### Tests
+
+```bash
+cd cpp
+make test
+```
+
+Tests use Catch2 and live in [`tests/`](./tests/).
+
+
+## Explanation
+
+### Why partial?
+
+The C++ port covers value-shape utilities and basic `walk` / `merge`.
+Major subsystems are not implemented yet.  Tracked in
+[`../REPORT.md`](../REPORT.md).
+
+### Known issues
+
+- `walk()` casts function pointers through `intptr_t` via the JSON
+  value -- this is undefined behaviour and needs replacing with a
+  proper callback type.
+- `clone()` is a shallow copy; the canonical is deep.
+- `merge()` is partially implemented; significant blocks are
+  commented out.
+- All functions use `args_container&&`; types are not yet enforced.
+- Debug `std::cout` calls remain in the source.
+
+These are tracked as P0/P1/P2 in [`../REPORT.md`](../REPORT.md).
+
+### Object model
+
+The port uses `nlohmann::json` for the container type.  This is
+reference-stable for nested values, which is the property the
+canonical algorithm requires.
+
+### Path syntax not yet supported
+
+`getpath` / `setpath` are missing, so the canonical
+"path-as-dot-string" calls do not work yet.  Use repeated
+`getprop` calls to walk into nested data, or wait for the path API
+to land.
+
+
+## Build and test
+
+```bash
+cd cpp
+make build
+make test
+```
+
+The overview / scratch examples in [`overview/`](./overview/) show
+the current API in use.

--- a/cs/DOCS.md
+++ b/cs/DOCS.md
@@ -1,0 +1,164 @@
+# Struct for C#
+
+> C# / .NET port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+Inside the monorepo:
+
+```bash
+cd cs
+dotnet restore
+```
+
+The project is `VoxgigStruct` targeting `net8.0`.  Namespace is
+`Voxgig.Struct`.
+
+### A first transform
+
+```csharp
+using Voxgig.Struct;
+
+var data = new Dictionary<string, object?> {
+    ["user"] = new Dictionary<string, object?> {
+        ["first"] = "Ada", ["last"] = "Lovelace",
+    },
+    ["age"] = 36,
+};
+
+var spec = new Dictionary<string, object?> {
+    ["name"]    = "`user.first`",
+    ["surname"] = "`user.last`",
+    ["years"]   = "`age`",
+};
+
+var out_ = Struct.Transform(data, spec);
+// out_ == { name: "Ada", surname: "Lovelace", years: 36 }
+```
+
+### Validate
+
+```csharp
+Struct.Validate(out_, new Dictionary<string, object?> {
+    ["name"]    = "`$STRING`",
+    ["surname"] = "`$STRING`",
+    ["years"]   = "`$INTEGER`",
+});
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```csharp
+Struct.GetPath("db.host", config);
+Struct.GetProp(node, "count", 0);
+Struct.GetDef(maybe, "fallback");
+```
+
+### Set a deep value
+
+```csharp
+var store = new Dictionary<string, object?>();
+Struct.SetPath(store, "db.host", "localhost");
+```
+
+### Merge
+
+```csharp
+var cfg = Struct.Merge(new List<object?> { defaults, file, env });
+```
+
+### Walk
+
+```csharp
+Struct.Walk(tree, (key, val, parent, path) =>
+    val is null ? "DEFAULT" : val);
+```
+
+
+## Reference
+
+Source: [`Struct.cs`](./Struct.cs).  Namespace `Voxgig.Struct`.  All
+API is on the `Struct` static class.
+
+### Naming convention
+
+C# uses PascalCase for public members:
+
+| Canonical   | C#            |
+|-------------|---------------|
+| `getpath`   | `GetPath`     |
+| `setpath`   | `SetPath`     |
+| `getprop`   | `GetProp`     |
+| `isnode`    | `IsNode`      |
+| `keysof`    | `KeysOf`      |
+
+### Type bit-flags
+
+```csharp
+Voxgig.Struct.T.Any
+Voxgig.Struct.T.NoVal
+Voxgig.Struct.T.Boolean
+Voxgig.Struct.T.Decimal
+Voxgig.Struct.T.Integer
+Voxgig.Struct.T.Number
+Voxgig.Struct.T.Str           // String reserved -> "Str"
+Voxgig.Struct.T.Func
+Voxgig.Struct.T.Symbol
+Voxgig.Struct.T.Null
+// ... List, Map, Instance, Scalar, Node
+```
+
+### Tests
+
+```bash
+cd cs
+dotnet test
+```
+
+Tests live in [`tests/`](./tests/) and consume fixtures from
+[`../build/test/`](../build/test/).
+
+
+## Explanation
+
+### `null` and `object?`
+
+C# 8+ nullable reference types are enabled (`<Nullable>enable</Nullable>`)
+and the API exposes nullable references throughout.  `null` represents
+JSON null and "absent" alike, the same convention used in Go and
+Java.
+
+### Identifier name collisions
+
+Some canonical names collide with C# reserved or stdlib identifiers:
+
+- `T.Str` instead of `T.String` (avoids the BCL `System.String`).
+- `T.Func` instead of `T.Function`.
+
+The functional behaviour is unchanged.
+
+### Status
+
+In progress.  Coverage is being expanded; check the parity matrix in
+[`../REPORT.md`](../REPORT.md) for the latest function and command
+status.
+
+
+## Build and test
+
+```bash
+cd cs
+dotnet restore
+dotnet test
+```

--- a/go/DOCS.md
+++ b/go/DOCS.md
@@ -1,0 +1,225 @@
+# Struct for Go
+
+> Full-parity Go port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+Module path: `github.com/voxgig/struct/go`.
+
+```bash
+go get github.com/voxgig/struct/go
+```
+
+### A first transform
+
+```go
+package main
+
+import (
+    "fmt"
+    voxgigstruct "github.com/voxgig/struct/go"
+)
+
+func main() {
+    data := map[string]any{
+        "user": map[string]any{"first": "Ada", "last": "Lovelace"},
+        "age":  36,
+    }
+
+    spec := map[string]any{
+        "name":    "`user.first`",
+        "surname": "`user.last`",
+        "years":   "`age`",
+    }
+
+    out, _ := voxgigstruct.Transform(data, spec)
+    fmt.Println(out)
+    // map[name:Ada surname:Lovelace years:36]
+}
+```
+
+### Validate
+
+```go
+out, err := voxgigstruct.Validate(data, map[string]any{
+    "name":    "`$STRING`",
+    "surname": "`$STRING`",
+    "years":   "`$INTEGER`",
+})
+if err != nil {
+    // shape did not match
+}
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```go
+v := voxgigstruct.GetPath("db.host", config)        // any (nil if absent)
+v := voxgigstruct.GetProp(node, "count", 0)         // 0 if absent
+v := voxgigstruct.GetDef(maybe, "fallback")         // maybe unless nil
+```
+
+### Set a deep value
+
+```go
+store := map[string]any{}
+voxgigstruct.SetPath(store, "db.host", "localhost")
+// store == map[db:map[host:localhost]]
+```
+
+### Merge a chain of maps
+
+```go
+cfg := voxgigstruct.Merge([]any{defaults, file, env})
+```
+
+### Walk a tree
+
+```go
+voxgigstruct.Walk(tree, func(key any, val any, parent any, path []string) any {
+    if val == nil {
+        return "DEFAULT"
+    }
+    return val
+})
+```
+
+### Inject and select
+
+```go
+voxgigstruct.Inject(spec, store)
+voxgigstruct.Select(map[string]any{"age": 30}, db)
+```
+
+
+## Reference
+
+Source: [`voxgigstruct.go`](./voxgigstruct.go).  Package
+`voxgigstruct`.
+
+### Naming convention
+
+Go uses PascalCase for exported identifiers, so functions are
+capitalised:
+
+| Canonical   | Go            |
+|-------------|---------------|
+| `getpath`   | `GetPath`     |
+| `setpath`   | `SetPath`     |
+| `getprop`   | `GetProp`     |
+| `setprop`   | `SetProp`     |
+| `isnode`    | `IsNode`      |
+| `keysof`    | `KeysOf`      |
+
+All other names follow the same rule.
+
+### Major functions
+
+```go
+func Walk(node any, apply WalkApply) any
+func WalkDescend(node any, apply WalkApply, before WalkApply, after WalkApply, maxdepth int) any
+func Merge(list []any, maxdepth ...int) any
+func GetPath(path any, store any) any
+func SetPath(store any, path any, val any) any
+func Inject(val any, store any) any
+func Transform(data any, spec any) (any, error)
+func Validate(data any, spec any) (any, error)
+func Select(query any, obj any) []any
+```
+
+### Go-specific extras
+
+- `ItemsApply(val, apply)` -- separate from `Items` (Go has no
+  overloading).
+- `CloneFlags(val, flags)` -- clone with options (Go lacks optional
+  parameters).
+- `TransformModify`, `TransformModifyHandler`, `TransformCollect` --
+  variants of `Transform` for callback styles.
+- `JoinUrl(parts)` -- URL-mode join.
+- `Jo(...)` / `Ja(...)` -- aliases for `Jm` / `Jt` (JSON Object /
+  JSON Array).
+- `ListRef[T]` -- generic wrapper for mutable list references; see
+  Explanation.
+
+### Constants
+
+```go
+const (
+    T_any, T_noval, T_boolean, T_decimal, T_integer, T_number,
+    T_string, T_function, T_symbol, T_null,
+    T_list, T_map, T_instance, T_scalar, T_node int = ...
+)
+const (
+    M_KEYPRE, M_KEYPOST, M_VAL int = ...
+)
+var SKIP, DELETE any           // sentinel objects
+var MODENAME []string
+var PLACEMENT ...
+```
+
+### Tests
+
+```bash
+cd go
+make test           # 92/92 passing
+```
+
+
+## Explanation
+
+### `nil` covers both undefined and null
+
+Go has only `nil`.  JSON null and "absent" both map to `nil` in the
+port.  Where the test corpus needs to distinguish them, the test
+runner uses the string sentinels `__NULL__` and `__UNDEFMARK__`.
+
+### Validate returns `(any, error)`
+
+This matches Go's idiom for fallible operations.  Errors carry a
+human-readable message describing the first mismatch (or an
+aggregate, if the underlying call collected errors).
+
+### Why `ListRef[T]`
+
+Go slices are values: appending to a slice may allocate a new
+backing array, breaking pointer-stability that the canonical
+algorithm relies on.  `ListRef[T]` is a thin generic wrapper
+(`*[]T`) that gives every holder a stable reference.  You only see
+it when you need to share a list across `walk` callbacks or mutate
+during a `merge`.
+
+### Multiple variants instead of optional parameters
+
+Go has no optional or named parameters, so utilities that take
+options in the canonical API (e.g. `Walk` with `before`/`after`)
+appear as multiple variants: `Walk`, `WalkDescend`, etc.  Pick the
+shortest that gives you what you need.
+
+### Naming
+
+Tests and code use the Go canonical capitalisation.  When a
+documentation source mentions `getpath`, the Go equivalent is
+`GetPath`; when it mentions `KEYPRE`, Go has `M_KEYPRE`.
+
+
+## Build and test
+
+```bash
+cd go
+go build ./...
+go test ./...           # or `make test`
+```
+
+Tests in `voxgigstruct_test.go` consume fixtures from
+[`../build/test/`](../build/test/).

--- a/java/DOCS.md
+++ b/java/DOCS.md
@@ -1,0 +1,191 @@
+# Struct for Java
+
+> Java port of the canonical TypeScript implementation.
+> **Status: partial.**  Basic utilities are present; major
+> subsystems (`inject`, `transform`, `validate`, `select`) are not
+> yet implemented.  Use the canonical TS or one of the complete ports
+> for production work.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).  For the parity matrix see
+[`../REPORT.md`](../REPORT.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first lookup
+
+### Install
+
+Inside the monorepo:
+
+```bash
+cd java
+mvn package        # or `make build`
+```
+
+Group / artifact: `voxgig:struct`.  Single class:
+`voxgig.struct.Struct`.
+
+### A first lookup
+
+```java
+import voxgig.struct.Struct;
+import java.util.Map;
+
+Map<String, Object> store = Map.of(
+    "db", Map.of("host", "localhost", "port", 5432)
+);
+
+Object host = Struct.getProp(
+    Struct.getProp(store, "db"),
+    "host"
+);
+// host == "localhost"
+```
+
+`Struct.getPath` and `Struct.setPath` are not yet implemented; once
+they land, the canonical pattern will be:
+
+```java
+Object host = Struct.getPath("db.host", store);
+```
+
+
+## How-to recipes (current scope)
+
+The currently-implemented functions are:
+
+```
+typify, typename, isFunc, isNode, isMap, isList, isEmpty, isKey,
+getProp, setProp, hasKey, keysof, items, pathify, stringify,
+escapeRegex, escapeUrl, joinUrl,
+clone, walk
+```
+
+### Test value shapes
+
+```java
+Struct.isNode(value);
+Struct.isMap(value);
+Struct.isList(value);
+```
+
+### Read / write a single property
+
+```java
+Object v = Struct.getProp(node, "key");
+Struct.setProp(node, "key", value);
+```
+
+### Walk a tree (post-order only, currently)
+
+```java
+Struct.walk(tree, (key, val, parent, path) ->
+    val == null ? "DEFAULT" : val);
+```
+
+The canonical `walk` supports `before` and `after` callbacks and a
+`maxdepth`; the Java port currently does post-order only.
+
+### Clone
+
+```java
+Object copy = Struct.clone(value);
+```
+
+
+## Reference
+
+Source: [`src/Struct.java`](./src/Struct.java).  Package
+`voxgig.struct`.
+
+### Constants
+
+All 15 type bit-flags are present:
+
+```java
+Struct.T_any, Struct.T_noval, Struct.T_boolean, Struct.T_decimal,
+Struct.T_integer, Struct.T_number, Struct.T_string,
+Struct.T_function, Struct.T_symbol, Struct.T_null,
+Struct.T_list, Struct.T_map, Struct.T_instance,
+Struct.T_scalar, Struct.T_node
+```
+
+Sentinels (`SKIP`, `DELETE`) and mode constants
+(`M_KEYPRE`/`M_KEYPOST`/`M_VAL`) are not yet defined.
+
+### Naming convention
+
+Java uses camelCase for methods:
+
+| Canonical    | Java          |
+|--------------|---------------|
+| `getprop`    | `getProp`     |
+| `setprop`    | `setProp`     |
+| `isnode`     | `isNode`      |
+| `keysof`     | `keysof`      |
+| `escre`      | `escapeRegex` |
+| `escurl`     | `escapeUrl`   |
+
+### Tests
+
+```bash
+cd java
+make test
+```
+
+The test runner is minimal -- there is no standard JUnit
+configuration in the build environment yet.  See
+[`../REPORT.md`](../REPORT.md) for full status.
+
+
+## Explanation
+
+### Why partial?
+
+The Java port currently covers the minor utilities and the basic
+`walk`.  The major subsystems (`inject`, `transform`, `validate`,
+`select`) need:
+
+1. `getpath` / `setpath` as the foundation;
+2. an `Injection` class to carry walk state;
+3. the `SKIP` / `DELETE` sentinels;
+4. transform-command and validate-checker dispatch tables.
+
+These are listed as P0/P1 items in [`../REPORT.md`](../REPORT.md).
+
+### Known issues
+
+- `keysof()` returns a list of zeros for `List` inputs instead of
+  string indices.
+- `walk()` is post-order only.
+- `escapeRegex()` uses `Pattern.quote()` wrapping rather than
+  per-character escaping; output differs from the canonical.
+- `stringify()` format diverges from canonical.
+
+These are tracked in [`../REPORT.md`](../REPORT.md).
+
+### `null` conventions
+
+Java has only `null`.  As in Go, `null` covers both JSON null and
+"absent".  Once the validate and transform subsystems land, they will
+use the same `__NULL__` test sentinel as other ports.
+
+### Object model
+
+The port uses `LinkedHashMap<String,Object>` for maps and
+`ArrayList<Object>` for lists by default.  Both are
+reference-stable, so the canonical "lists are mutable in place"
+property holds without a wrapper.
+
+
+## Build and test
+
+```bash
+cd java
+mvn package
+make test
+```
+
+Tests live in [`src/test/`](./src/test/).

--- a/js/DOCS.md
+++ b/js/DOCS.md
@@ -1,0 +1,197 @@
+# Struct for JavaScript
+
+> The plain-JavaScript port.  Runtime-identical to the TypeScript
+> canonical implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+The JS source lives in [`src/struct.js`](./src/struct.js) as a
+CommonJS module.  Inside the monorepo:
+
+```js
+const struct = require('./js/src/struct.js')
+```
+
+### A first transform
+
+```js
+const { transform } = require('./js/src/struct.js')
+
+const data = { user: { first: 'Ada', last: 'Lovelace' }, age: 36 }
+
+const spec = {
+  name: '`user.first`',
+  surname: '`user.last`',
+  years: '`age`',
+}
+
+console.log(transform(data, spec))
+// { name: 'Ada', surname: 'Lovelace', years: 36 }
+```
+
+### Validate the result
+
+```js
+const { validate } = require('./js/src/struct.js')
+
+validate(out, {
+  name: '`$STRING`',
+  surname: '`$STRING`',
+  years: '`$INTEGER`',
+})
+```
+
+`validate` returns the value on success and throws on mismatch.
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```js
+const { getpath, getprop, getdef } = require('./js/src/struct.js')
+
+getpath('db.host', config)              // value or undefined
+getprop(node, 'count', 0)               // 0 if absent
+getdef(maybe, 'fallback')               // returns maybe unless undefined
+```
+
+### Set a deep value
+
+```js
+const { setpath } = require('./js/src/struct.js')
+
+const store = {}
+setpath(store, 'db.host', 'localhost')
+// store.db.host === 'localhost'
+```
+
+### Deep-merge configs
+
+```js
+const { merge } = require('./js/src/struct.js')
+
+const cfg = merge([defaults, file, env])
+```
+
+### Walk a tree
+
+```js
+const { walk } = require('./js/src/struct.js')
+
+walk(tree, (key, val, parent, path) => {
+  return val === null ? 'DEFAULT' : val
+})
+```
+
+The `path` argument is reused; clone with `path.slice()` to keep it.
+
+### Inject references into a template
+
+```js
+const { inject } = require('./js/src/struct.js')
+
+inject(
+  { greeting: 'hello `name`', age: '`years`' },
+  { name: 'Ada', years: 36 }
+)
+// { greeting: 'hello Ada', age: 36 }
+```
+
+### Select records by query
+
+```js
+const { select } = require('./js/src/struct.js')
+
+select(
+  { age: 30 },
+  { a: { name: 'Alice', age: 30 }, b: { name: 'Bob', age: 25 } }
+)
+// [ { name: 'Alice', age: 30, $KEY: 'a' } ]
+```
+
+
+## Reference
+
+### Module shape
+
+```js
+module.exports = {
+  StructUtility, Injection,
+
+  // 41 functions (40 canonical + replace exposed publicly)
+  clone, delprop, escre, escurl, filter, flatten, getdef, getelem,
+  getpath, getprop, haskey, inject, isempty, isfunc, iskey, islist,
+  ismap, isnode, items, join, jsonify, keysof, merge, pad, pathify,
+  replace, select, setpath, setprop, size, slice, strkey, stringify,
+  transform, typify, typename, validate, walk, jm, jt,
+  checkPlacement, injectorArgs, injectChild,
+
+  // sentinels
+  SKIP, DELETE,
+
+  // 15 type bit-flags
+  T_any, T_noval, T_boolean, T_decimal, T_integer, T_number, T_string,
+  T_function, T_symbol, T_null, T_list, T_map, T_instance, T_scalar,
+  T_node,
+
+  // mode flags
+  M_KEYPRE, M_KEYPOST, M_VAL, MODENAME,
+}
+```
+
+### Differences from canonical TypeScript
+
+- `replace(s, fromPat, toStr)` is exported (internal in TS).
+- Identical runtime semantics -- both run on V8/JS engines.
+- Test count: 84/84 passing.
+
+For full signatures, see the [canonical TypeScript
+docs](../ts/DOCS.md#reference).
+
+
+## Explanation
+
+### `null` vs `undefined`
+
+JavaScript distinguishes the two natively, and `struct` preserves the
+distinction:
+
+- `undefined` means "absent" -- `getprop` returns `undefined` for a
+  missing key, and most predicates treat `undefined` as not-a-node.
+- `null` is the JSON null value -- a defined scalar.
+
+When a JSON parser hands you `null` for an absent field, you may want
+to convert it to `undefined` (or use `'__NULL__'` as a placeholder)
+before passing into `struct`.  See [README §Concepts](../README.md#concepts).
+
+### Lists are mutated in place
+
+`merge`, `setpath`, and `inject` rely on lists being reference-stable.
+This is JavaScript's natural behaviour; no wrapper needed.
+
+### Why a hand-written JS file alongside the TypeScript
+
+The JS file is hand-maintained for legibility and ports that want to
+follow the JS code rather than read TypeScript types.  Both files
+agree on behaviour, enforced by the shared test corpus.
+
+
+## Build and test
+
+```bash
+cd js
+npm install
+make test           # runs the .jsonic corpus
+```
+
+Tests live in [`test/`](./test/) and read fixtures from
+[`../build/test/`](../build/test/).

--- a/lua/DOCS.md
+++ b/lua/DOCS.md
@@ -1,0 +1,190 @@
+# Struct for Lua
+
+> Full-parity Lua port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).  For build / test setup specifics
+see [`README.md`](./README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+The module is a single file: [`src/struct.lua`](./src/struct.lua).
+Tests use LuaRocks; see [`README.md`](./README.md) for full setup.
+
+```bash
+cd lua
+make setup       # installs lua + luarocks deps
+```
+
+### A first transform
+
+```lua
+package.path = './src/?.lua;' .. package.path
+local struct = require('struct')
+
+local data = {
+  user = { first = 'Ada', last = 'Lovelace' },
+  age  = 36,
+}
+
+local spec = {
+  name    = '`user.first`',
+  surname = '`user.last`',
+  years   = '`age`',
+}
+
+local out = struct.transform(data, spec)
+-- out == { name = 'Ada', surname = 'Lovelace', years = 36 }
+```
+
+### Validate
+
+```lua
+struct.validate(out, {
+  name    = '`$STRING`',
+  surname = '`$STRING`',
+  years   = '`$INTEGER`',
+})
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```lua
+struct.getpath('db.host', config)
+struct.getprop(node, 'count', 0)
+struct.getdef(maybe, 'fallback')
+```
+
+### Set a deep value
+
+```lua
+local store = {}
+struct.setpath(store, 'db.host', 'localhost')
+-- store.db.host == 'localhost'
+```
+
+### Merge configs
+
+```lua
+local cfg = struct.merge({ defaults, file, env })
+```
+
+### Walk a tree
+
+```lua
+struct.walk(tree, function(key, val, parent, path)
+  if val == nil then
+    return 'DEFAULT'
+  end
+  return val
+end)
+```
+
+### Inject and select
+
+```lua
+struct.inject(
+  { greeting = 'hello `name`' },
+  { name = 'Ada' }
+)
+
+struct.select({ age = 30 }, records)
+```
+
+
+## Reference
+
+Source: [`src/struct.lua`](./src/struct.lua).
+
+### Module shape
+
+```lua
+return {
+  -- 41 functions
+  clone, delprop, escre, escurl, filter, flatten, getdef, getelem,
+  getpath, getprop, haskey, inject, isempty, isfunc, iskey, islist,
+  ismap, isnode, items, join, jsonify, keysof, merge, pad, pathify,
+  replace, select, setpath, setprop, size, slice, strkey, stringify,
+  transform, typify, typename, validate, walk, jm, jt,
+  checkPlacement, injectorArgs, injectChild,
+
+  -- sentinels and constants
+  SKIP, DELETE,
+  T_any, T_noval, T_boolean, T_decimal, T_integer, T_number,
+  T_string, T_function, T_symbol, T_null,
+  T_list, T_map, T_instance, T_scalar, T_node,
+  M_KEYPRE, M_KEYPOST, M_VAL,
+  MODENAME,
+}
+```
+
+### Tests
+
+```bash
+cd lua
+make test           # 75/75 passing
+```
+
+
+## Explanation
+
+### One container type, two roles
+
+Lua tables are unified: a "list" and a "map" are both tables.  The
+port distinguishes them with the `__jsontype` metatable field
+(`'array'` vs `'object'`).  `ismap` and `islist` consult this field;
+`stringify` and `jsonify` use it when serialising.
+
+When you build a table from Lua literals, you can hint with
+`setmetatable(t, { __jsontype = 'array' })`, or simply use `jt(...)`
+/ `jm(...)` builders.
+
+### 1-based versus 0-based indexing
+
+Lua arrays are 1-based natively.  The external API still presents
+0-based indexing for consistency with the canonical API: `getpath('0',
+list)` returns the first element, even though internally the list is
+stored at index 1.  The translation happens inside the port.
+
+`items()` returns Lua tables of the form `{key, val}` rather than
+two-element arrays.  The keys and values match the canonical
+positions.
+
+### `escre` escapes Lua patterns
+
+Lua does not have full regex; it has Lua patterns.  `escre` escapes
+the metacharacters used in Lua patterns, not in PCRE.  The function
+exists only for callers that hand the result to `string.match` /
+`string.gsub`; downstream regex engines are not affected.
+
+### `nil` is "absent"
+
+Lua has no separate undefined keyword; `nil` covers both "absent"
+and "JSON null".  Where the test corpus needs to distinguish them,
+the runner uses string sentinels.
+
+### Lists are mutable in place
+
+Lua tables are reference types, so the canonical "lists are
+reference-stable" assumption holds without a wrapper.
+
+
+## Build and test
+
+```bash
+cd lua
+make setup
+make test
+```
+
+Tests live in [`test/struct_test.lua`](./test/struct_test.lua) and
+consume fixtures from [`../build/test/`](../build/test/).  See
+[`README.md`](./README.md) for the original test-runner setup guide.

--- a/php/DOCS.md
+++ b/php/DOCS.md
@@ -1,0 +1,216 @@
+# Struct for PHP
+
+> Full-parity PHP port of the canonical TypeScript implementation.
+> All functionality is exposed as static methods on `Voxgig\Struct\Struct`.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+Composer:
+
+```bash
+composer require voxgig/struct
+```
+
+In the monorepo:
+
+```bash
+cd php
+composer install
+```
+
+### A first transform
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Voxgig\Struct\Struct;
+
+$data = [
+    'user' => ['first' => 'Ada', 'last' => 'Lovelace'],
+    'age'  => 36,
+];
+
+$spec = [
+    'name'    => '`user.first`',
+    'surname' => '`user.last`',
+    'years'   => '`age`',
+];
+
+print_r(Struct::transform($data, $spec));
+// Array ( [name] => Ada [surname] => Lovelace [years] => 36 )
+```
+
+### Validate
+
+```php
+Struct::validate($out, [
+    'name'    => '`$STRING`',
+    'surname' => '`$STRING`',
+    'years'   => '`$INTEGER`',
+]);
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```php
+Struct::getpath('db.host', $config);
+Struct::getprop($node, 'count', 0);
+Struct::getdef($maybe, 'fallback');
+```
+
+### Set a deep value
+
+```php
+$store = [];
+Struct::setpath($store, 'db.host', 'localhost');
+// $store === ['db' => ['host' => 'localhost']]
+```
+
+Note: PHP arrays are value types, so `setprop` accepts the parent
+**by reference** (`&$parent`).
+
+### Merge configs
+
+```php
+$cfg = Struct::merge([$defaults, $file, $env]);
+```
+
+### Walk a tree
+
+```php
+Struct::walk($tree, function ($key, $val, $parent, $path) {
+    return $val === null ? 'DEFAULT' : $val;
+});
+```
+
+### Inject and select
+
+```php
+Struct::inject(['greeting' => 'hello `name`'], ['name' => 'Ada']);
+Struct::select(['age' => 30], $records);
+```
+
+
+## Reference
+
+Source: [`src/Struct.php`](./src/Struct.php).  Namespace
+`Voxgig\Struct`.  All API is on the `Struct` class as public static
+methods.
+
+### Method list (46)
+
+All 40 canonical functions plus PHP-specific helpers:
+
+```
+typename, getdef, isnode, ismap, islist, iskey, isempty, isfunc,
+size, slice, pad, typify, getelem, getprop, strkey, keysof, haskey,
+items, flatten, filter, escre, escurl, join, jsonify, stringify,
+pathify, clone, delprop, setprop,
+walk, merge, setpath, getpath, inject, transform, validate, select,
+jm, jt,
+checkPlacement, injectorArgs, injectChild,
+
+// PHP additions
+replace, joinurl, cloneWrap, cloneUnwrap
+```
+
+### Constants
+
+`Struct` exposes the canonical constants as class constants:
+
+```php
+Struct::SKIP
+Struct::DELETE
+Struct::T_string
+Struct::M_KEYPRE
+// ... etc
+```
+
+### `ListRef`
+
+A wrapper class that gives lists reference semantics across calls
+that would otherwise copy them.  Used internally; you only need it
+if you write custom `Modify` callbacks that mutate lists.
+
+```php
+use Voxgig\Struct\ListRef;
+$ref = new ListRef([1, 2, 3]);
+```
+
+### Tests
+
+```bash
+cd php
+composer install
+make test           # 82/82 passing, 920 assertions
+```
+
+
+## Explanation
+
+### `UNDEF` is a string sentinel
+
+PHP has no separate "undefined" keyword.  The port uses the string
+`'__UNDEFINED__'` (`Struct::UNDEF`) as a sentinel for absent values.
+Most user-facing calls accept `null` as "absent" and return `null`
+when nothing is present, so you usually do not see the sentinel
+directly.
+
+### Arrays are value types
+
+PHP arrays copy on assignment, which breaks the canonical
+"reference-stable list" assumption.  Two adaptations:
+
+1. `setprop`, `setpath`, and similar mutating calls take their
+   parent **by reference** (`&$parent`).
+2. The `ListRef` class wraps a list when one needs to be shared
+   across calls (notably during `merge` and `inject`).
+
+This is the same pattern the Go port uses, for the same reason.
+
+### Maps and lists in PHP
+
+PHP has only one container type (the array) which can be associative
+("map") or numerically indexed ("list").  `struct` distinguishes the
+two with the same predicates as everywhere else: `Struct::ismap`,
+`Struct::islist`.  An array with non-sequential numeric keys is
+treated as a map.
+
+### Method casing
+
+PHP method names follow the canonical lowercase: `getpath`,
+`setpath`, `getprop`.  This breaks PSR-12 camelCase, but parity with
+other ports beats style.
+
+### Validate
+
+`Struct::validate` either:
+
+- returns the value, on success;
+- throws a `\RuntimeException` with the first error, by default;
+- accumulates into a passed errors array, if you supply one as the
+  fourth argument.
+
+
+## Build and test
+
+```bash
+cd php
+composer install
+make test
+```
+
+Tests in [`tests/`](./tests/) consume fixtures from
+[`../build/test/`](../build/test/).

--- a/py/DOCS.md
+++ b/py/DOCS.md
@@ -1,0 +1,241 @@
+# Struct for Python
+
+> Full-parity Python port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+The package is `voxgig_struct`.  Inside the monorepo:
+
+```bash
+cd py
+pip install -e .
+```
+
+Or import directly from the source tree:
+
+```python
+import sys
+sys.path.insert(0, '/path/to/struct/py')
+from voxgig_struct import transform, validate
+```
+
+### A first transform
+
+```python
+from voxgig_struct import transform
+
+data = {'user': {'first': 'Ada', 'last': 'Lovelace'}, 'age': 36}
+
+spec = {
+    'name': '`user.first`',
+    'surname': '`user.last`',
+    'years': '`age`',
+}
+
+print(transform(data, spec))
+# {'name': 'Ada', 'surname': 'Lovelace', 'years': 36}
+```
+
+### Validate
+
+```python
+from voxgig_struct import validate
+
+validate(out, {
+    'name':    '`$STRING`',
+    'surname': '`$STRING`',
+    'years':   '`$INTEGER`',
+})
+```
+
+`validate` returns the value on success and raises on mismatch.
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```python
+from voxgig_struct import getpath, getprop, getdef
+
+getpath('db.host', config)            # value or None
+getprop(node, 'count', 0)             # 0 if absent
+getdef(maybe, 'fallback')             # returns maybe unless None
+```
+
+### Set a deep value, creating intermediate dicts
+
+```python
+from voxgig_struct import setpath
+
+store = {}
+setpath(store, 'db.host', 'localhost')
+# store == {'db': {'host': 'localhost'}}
+```
+
+### Deep-merge a chain of dicts
+
+```python
+from voxgig_struct import merge
+
+cfg = merge([defaults, file_config, env_overrides])
+```
+
+### Walk a tree (keyword args)
+
+```python
+from voxgig_struct import walk
+
+def apply(key, val, parent, path):
+    return 'DEFAULT' if val is None else val
+
+walk(tree, apply)
+# Optional keyword arguments: before=, after=, maxdepth=
+```
+
+### Inject references into a template
+
+```python
+from voxgig_struct import inject
+
+inject(
+    {'greeting': 'hello `name`', 'age': '`years`'},
+    {'name': 'Ada', 'years': 36},
+)
+# {'greeting': 'hello Ada', 'age': 36}
+```
+
+### Select records by query
+
+```python
+from voxgig_struct import select
+
+select(
+    {'age': 30},
+    {'a': {'name': 'Alice', 'age': 30}, 'b': {'name': 'Bob', 'age': 25}},
+)
+# [{'name': 'Alice', 'age': 30, '$KEY': 'a'}]
+```
+
+
+## Reference
+
+Source: [`voxgig_struct/voxgig_struct.py`](./voxgig_struct/voxgig_struct.py).
+
+### Top-level imports
+
+```python
+from voxgig_struct import (
+    # 40+ functions
+    clone, delprop, escre, escurl, filter, flatten,
+    getdef, getelem, getpath, getprop, haskey,
+    inject, isempty, isfunc, iskey, islist, ismap, isnode,
+    items, join, joinurl, jsonify, keysof, merge,
+    pad, pathify, replace, select, setpath, setprop,
+    size, slice, strkey, stringify, transform,
+    typename, typify, validate, walk,
+
+    # builders + aliases
+    jm, jt, jo, ja,
+
+    # injection helpers
+    Injection, StructUtility,
+    checkPlacement, injectorArgs, injectChild,
+
+    # sentinels and constants
+    SKIP, DELETE,
+    T_any, T_noval, T_boolean, T_decimal, T_integer, T_number,
+    T_string, T_function, T_symbol, T_null,
+    T_list, T_map, T_instance, T_scalar, T_node,
+    M_KEYPRE, M_KEYPOST, M_VAL,
+)
+```
+
+### Major functions
+
+```python
+walk(node, apply, before=None, after=None, maxdepth=None) -> any
+merge(items, maxdepth=None) -> any
+getpath(path, store) -> any
+setpath(store, path, val) -> store
+inject(val, store, modify=None) -> any
+transform(data, spec, extra=None, modify=None) -> any
+validate(data, spec, extra=None, collecterrs=None) -> any
+select(query, obj) -> list
+```
+
+### Python-specific extras
+
+- `replace(s, from_pat, to_str)` -- explicit string/regex replace
+  (internal in canonical TS).
+- `joinurl(parts)` -- convenience for `join(parts, '/', True)`.
+- `jo(...)` / `ja(...)` -- aliases for `jm` / `jt` ("JSON
+  Object", "JSON Array").
+
+### Sentinels and constants
+
+- `SKIP`, `DELETE` -- transform/inject control sentinels.
+- `T_*` -- 15 type bit-flags, returned by `typify(val)`.
+- `M_KEYPRE`, `M_KEYPOST`, `M_VAL` -- walk/inject phase tags.
+
+### Tests
+
+```bash
+cd py
+make test           # 84/84 passing against the shared corpus
+```
+
+
+## Explanation
+
+### `None`, `null`, and `UNDEF`
+
+Python has a single `None`.  JSON distinguishes "absent" from "null".
+The port treats absent values the same as `None` in most cases, and
+the test fixtures use the string sentinels `__NULL__` and
+`__UNDEFMARK__` where the distinction must be preserved.
+
+```python
+typify(None)   # T_scalar | T_null
+```
+
+The internal `UNDEF` sentinel is `None` in Python; this is a
+deliberate choice for ergonomics.  See `voxgig_struct.py`:`UNDEF`.
+
+### Walk uses keyword arguments
+
+Where the canonical TS has positional optional arguments, the Python
+port uses keyword arguments (`before=`, `after=`, `maxdepth=`).  This
+is idiomatic Python and avoids ambiguity.
+
+### Naming convention
+
+Python uses lowercase function names matching the TS canonical
+exactly: `getpath`, `setpath`, `getprop`.  PEP 8 would have suggested
+`get_path`, but parity beats style here -- the same name in every
+language is the whole point.
+
+### Lists and dicts are mutated in place
+
+Same rule as the canonical: `merge`, `setpath`, `inject` mutate
+container values in place.  Pass a `clone` first if you need an
+immutable input.
+
+
+## Build and test
+
+```bash
+cd py
+make test
+```
+
+Tests in [`tests/`](./tests/) read fixtures from
+[`../build/test/`](../build/test/).

--- a/rb/DOCS.md
+++ b/rb/DOCS.md
@@ -1,0 +1,180 @@
+# Struct for Ruby
+
+> Full-parity Ruby port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+In the monorepo:
+
+```bash
+cd rb
+bundle install
+```
+
+The library is a single file: [`voxgig_struct.rb`](./voxgig_struct.rb).
+Module: `VoxgigStruct`.
+
+### A first transform
+
+```ruby
+require_relative 'voxgig_struct'
+
+data = {
+  'user' => { 'first' => 'Ada', 'last' => 'Lovelace' },
+  'age'  => 36,
+}
+
+spec = {
+  'name'    => '`user.first`',
+  'surname' => '`user.last`',
+  'years'   => '`age`',
+}
+
+puts VoxgigStruct.transform(data, spec).inspect
+# {"name"=>"Ada", "surname"=>"Lovelace", "years"=>36}
+```
+
+### Validate
+
+```ruby
+VoxgigStruct.validate(out, {
+  'name'    => '`$STRING`',
+  'surname' => '`$STRING`',
+  'years'   => '`$INTEGER`',
+})
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```ruby
+VoxgigStruct.getpath('db.host', config)
+VoxgigStruct.getprop(node, 'count', 0)
+VoxgigStruct.getdef(maybe, 'fallback')
+```
+
+### Set a deep value
+
+```ruby
+store = {}
+VoxgigStruct.setpath(store, 'db.host', 'localhost')
+# store == { 'db' => { 'host' => 'localhost' } }
+```
+
+### Merge configs
+
+```ruby
+cfg = VoxgigStruct.merge([defaults, file, env])
+```
+
+### Walk a tree
+
+```ruby
+VoxgigStruct.walk(tree) do |key, val, parent, path|
+  val.nil? ? 'DEFAULT' : val
+end
+```
+
+### Inject and select
+
+```ruby
+VoxgigStruct.inject(
+  { 'greeting' => 'hello `name`' },
+  { 'name' => 'Ada' }
+)
+
+VoxgigStruct.select({ 'age' => 30 }, records)
+```
+
+
+## Reference
+
+Source: [`voxgig_struct.rb`](./voxgig_struct.rb).  Module
+`VoxgigStruct`.
+
+### Method list
+
+All 40 canonical functions, plus:
+
+```
+replace, joinurl, checkPlacement, injectorArgs, injectChild,
+AND, OR, NOT, CMP   # select operators
+```
+
+### Constants
+
+```ruby
+VoxgigStruct::SKIP
+VoxgigStruct::DELETE
+VoxgigStruct::T_string  # ... 15 type constants
+VoxgigStruct::M_KEYPRE
+VoxgigStruct::M_KEYPOST
+VoxgigStruct::M_VAL
+VoxgigStruct::MODENAME
+VoxgigStruct::UNDEF
+```
+
+### `Injection` class
+
+Full implementation with `descend`, `child`, `setval` instance
+methods.
+
+### Tests
+
+```bash
+cd rb
+make test           # 75/75 passing, 150 assertions
+```
+
+
+## Explanation
+
+### `UNDEF`, `nil`, and JSON null
+
+Ruby has `nil`.  JSON has both `null` and "absent".  The port uses:
+
+- `nil` for JSON null.
+- `VoxgigStruct::UNDEF` (a frozen sentinel object) for "absent".
+
+`typify(nil)` returns `T_scalar | T_null`, distinct from `T_noval`
+returned for `UNDEF`.  Unless you are writing custom transform
+callbacks, you will only see `nil` in user-facing APIs.
+
+### Method naming
+
+The Ruby port uses lowercase method names (`getpath`, `setpath`,
+`getprop`) matching the canonical API, not Ruby's idiomatic
+snake_case.  Parity with other ports is the goal.
+
+### Validate naming
+
+The Ruby validate checkers use `$OBJECT` and `$ARRAY` rather than
+`$MAP` and `$LIST` (matching Ruby JSON conventions).  All other
+checker tokens are identical.
+
+### Walk-based merge
+
+`merge` is implemented as a `walk` with `before`/`after` callbacks
+and a `maxdepth` parameter, matching the canonical algorithm.
+
+
+## Build and test
+
+```bash
+cd rb
+bundle install
+make test
+```
+
+Tests live in [`test_voxgig_struct.rb`](./test_voxgig_struct.rb) and
+consume fixtures from [`../build/test/`](../build/test/).

--- a/ts/DOCS.md
+++ b/ts/DOCS.md
@@ -1,0 +1,313 @@
+# Struct for TypeScript
+
+> The canonical implementation.  Every other port matches the
+> behaviour defined here.
+
+This is the reference implementation of `@voxgig/struct`.  When other
+ports disagree with the shared test corpus, the corpus -- and this
+TypeScript code -- is right.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first transform
+
+### Install
+
+```bash
+npm install @voxgig/struct
+```
+
+### A first transform
+
+Create `hello.ts`:
+
+```ts
+import { transform, validate } from '@voxgig/struct'
+
+const data = {
+  user: { first: 'Ada', last: 'Lovelace' },
+  age: 36,
+}
+
+// A spec is data that mirrors the desired output.
+// Backtick-quoted strings are path references into `data`.
+const spec = {
+  name: '`user.first`',
+  surname: '`user.last`',
+  years: '`age`',
+}
+
+const out = transform(data, spec)
+console.log(out)
+// { name: 'Ada', surname: 'Lovelace', years: 36 }
+```
+
+### Add validation
+
+```ts
+const shape = {
+  name: '`$STRING`',
+  surname: '`$STRING`',
+  years: '`$INTEGER`',
+}
+
+validate(out, shape)   // returns out unchanged on success
+```
+
+If you hand `validate` a value that doesn't match, it throws.  Pass an
+errors-collector array as the fourth argument to collect rather than
+throw -- see [Reference](#reference).
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```ts
+import { getpath, getprop, getdef } from '@voxgig/struct'
+
+getpath('db.host', config)              // 'localhost' or undefined
+getpath(['db', 'host'], config)         // same, array form
+
+getprop(node, 'count', 0)               // 0 if absent
+getdef(maybe, 'fallback')               // returns maybe unless undefined
+```
+
+### Set a deep value, creating missing parents
+
+```ts
+import { setpath } from '@voxgig/struct'
+
+const store = {}
+setpath(store, 'db.host', 'localhost')
+// store === { db: { host: 'localhost' } }
+```
+
+### Merge a chain of configs
+
+```ts
+import { merge } from '@voxgig/struct'
+
+const cfg = merge([defaults, fileConfig, envOverrides])
+```
+
+Last input wins for scalars; maps deep-merge; lists merge by index.
+
+### Walk a tree
+
+```ts
+import { walk } from '@voxgig/struct'
+
+walk(tree, (key, val, parent, path) => {
+  // Return a replacement value, or `val` to leave unchanged.
+  return val === null ? 'DEFAULT' : val
+})
+```
+
+The `path` array is reused across calls; clone it (`path.slice()`)
+if you need to retain it.
+
+### Inject values into a template
+
+```ts
+import { inject } from '@voxgig/struct'
+
+inject(
+  { greeting: 'hello `name`', age: '`years`' },
+  { name: 'Ada', years: 36 }
+)
+// => { greeting: 'hello Ada', age: 36 }
+```
+
+### Pick records out of a node by query
+
+```ts
+import { select } from '@voxgig/struct'
+
+select(
+  { age: 30 },
+  { a: { name: 'Alice', age: 30 }, b: { name: 'Bob', age: 25 } }
+)
+// => [ { name: 'Alice', age: 30, $KEY: 'a' } ]
+```
+
+
+## Reference
+
+Source: [`src/StructUtility.ts`](./src/StructUtility.ts).
+
+### Installation
+
+```
+npm install @voxgig/struct
+```
+
+Package: `@voxgig/struct`.  Entry: `dist/StructUtility.js` /
+`dist/StructUtility.d.ts`.
+
+### Imports
+
+```ts
+import {
+  // minor utilities
+  typename, getdef, isnode, ismap, islist, iskey, isempty, isfunc,
+  size, slice, pad, typify, getelem, getprop, strkey, keysof,
+  haskey, items, flatten, filter, escre, escurl, join, jsonify,
+  stringify, pathify, clone, delprop, setprop,
+
+  // major utilities
+  walk, merge, setpath, getpath, inject, transform, validate, select,
+
+  // builders
+  jm, jt,
+
+  // injection helpers
+  checkPlacement, injectorArgs, injectChild,
+
+  // sentinels
+  SKIP, DELETE,
+
+  // type bit-flags
+  T_any, T_noval, T_boolean, T_decimal, T_integer, T_number, T_string,
+  T_function, T_symbol, T_null, T_list, T_map, T_instance, T_scalar,
+  T_node,
+
+  // walk/inject mode flags
+  M_KEYPRE, M_KEYPOST, M_VAL, MODENAME,
+
+  // class wrapper
+  StructUtility,
+
+  // type only
+  Injection,
+} from '@voxgig/struct'
+```
+
+### Major functions
+
+```ts
+function walk(
+  node: any,
+  apply: WalkApply,
+  before?: WalkApply,
+  after?: WalkApply,
+  maxdepth?: number,
+): any
+
+function merge(list: any[], maxdepth?: number): any
+
+function getpath(path: string | string[], store: any): any
+function setpath(store: any, path: string | string[], val: any): any
+
+function inject(val: any, store: any, modify?: Modify): any
+
+function transform(
+  data: any,
+  spec: any,
+  extra?: any,
+  modify?: Modify,
+): any
+
+function validate(
+  data: any,
+  spec: any,
+  extra?: any,
+  collecterrs?: string[],
+): any
+
+function select(query: any, obj: any): any[]
+```
+
+### Sentinels
+
+- `SKIP` -- returned from a transform/inject step to omit the key.
+- `DELETE` -- returned to remove the key from the parent.
+
+### `StructUtility` class
+
+`StructUtility` exposes every function and constant as instance
+properties, useful for dependency-injecting the API or stubbing it in
+tests.
+
+```ts
+import { StructUtility } from '@voxgig/struct'
+const su = new StructUtility()
+su.getpath('a.b', { a: { b: 1 } })   // 1
+```
+
+### Transform commands
+
+Used as quoted strings inside a `transform` spec:
+
+`$DELETE`, `$COPY`, `$KEY`, `$META`, `$ANNO`, `$MERGE`, `$EACH`,
+`$PACK`, `$REF`, `$FORMAT`, `$APPLY`.
+
+### Validate checkers
+
+Used as quoted strings inside a `validate` spec:
+
+`$MAP`, `$LIST`, `$STRING`, `$NUMBER`, `$INTEGER`, `$DECIMAL`,
+`$BOOLEAN`, `$NULL`, `$NIL`, `$FUNCTION`, `$INSTANCE`, `$ANY`,
+`$CHILD`, `$ONE`, `$EXACT`.
+
+
+## Explanation
+
+### Why TypeScript is canonical
+
+TypeScript is expressive enough to model `null` vs `undefined` vs
+absent without ceremony, has fast iteration on V8, and produces a
+.d.ts type signature that becomes the "contract" the other ports
+target.  The shared test corpus
+([`build/test/*.jsonic`](../build/test/)) is consumed by every port,
+so the canonical answers are produced from this implementation.
+
+### `null` versus `undefined`
+
+In TypeScript, `undefined` means "absent" and `null` is the JSON null
+value.  Most `getprop`/`getelem` paths return `undefined` when the
+key is missing, and accept an `alt` argument for a fallback.  When
+porting, this distinction matters: see the language-specific docs for
+each port's chosen sentinel.
+
+### Lists are mutable and reference-stable
+
+`walk`, `merge`, `inject`, and `setpath` all assume that mutating a
+list in place is visible to other holders of the same list.  This is
+free in JS/TS; ports to value-array languages (Go, PHP) introduce a
+`ListRef` wrapper to preserve the property.
+
+### Path syntax
+
+Paths are either:
+
+- a dot-separated string: `'a.b.0.c'`
+- an array: `['a', 'b', 0, 'c']`
+
+Integer-looking string keys index into lists; everything else indexes
+maps.
+
+### By-example specs
+
+A `transform` spec mirrors the desired output: keys, nesting, and
+default values are all literal.  The only special tokens are
+backtick-quoted strings (`` `path` ``, `` `$CMD` ``).  Likewise a
+`validate` spec is the shape of the accepted data with type tokens at
+the leaves.
+
+
+## Build and test
+
+```bash
+cd ts
+npm install
+npm run build      # tsc → dist/
+npm test           # node --test on dist-test
+```
+
+Tests live in [`test/`](./test/) and read fixtures from
+[`../build/test/`](../build/test/).

--- a/zig/DOCS.md
+++ b/zig/DOCS.md
@@ -1,0 +1,178 @@
+# Struct for Zig
+
+> Zig port of the canonical TypeScript implementation.
+
+For the language-neutral overview, motivation, and concepts, see the
+[top-level README](../README.md).
+
+These docs follow the [Diataxis](https://diataxis.fr/) framework.
+
+
+## Tutorial: your first lookup
+
+### Install
+
+Inside the monorepo:
+
+```bash
+cd zig
+zig build test
+```
+
+The package is `voxgig-struct`; the module is in
+[`src/struct.zig`](./src/struct.zig).
+
+### A first path lookup
+
+```zig
+const std = @import("std");
+const struct_lib = @import("struct");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    // Build a JsonValue tree.
+    var root = try struct_lib.JsonValue.makeMap(allocator);
+    defer root.deinit(allocator);
+
+    var db = try struct_lib.JsonValue.makeMap(allocator);
+    try db.object.put("host", .{ .string = "localhost" });
+    try root.object.put("db", db);
+
+    const path = struct_lib.JsonValue{ .string = "db.host" };
+    const val = try struct_lib.getpath(allocator, path, root);
+    // val == .{ .string = "localhost" }
+}
+```
+
+
+## How-to recipes
+
+### Read a deep value safely
+
+```zig
+const v = try struct_lib.getpath(allocator, path_val, store);
+const v = try struct_lib.getprop(allocator, store, key_val, alt_val);
+```
+
+### Set a deep value
+
+```zig
+_ = try struct_lib.setpath(allocator, store, path_val, new_val);
+```
+
+### Merge
+
+```zig
+const merged = try struct_lib.merge(allocator, list_of_maps, maxdepth);
+```
+
+### Walk
+
+```zig
+_ = try struct_lib.walk(
+    allocator,
+    tree,
+    apply_fn,         // *const fn(...) anyerror!JsonValue
+    .{ .before = null, .after = null, .maxdepth = 32 },
+);
+```
+
+### Transform
+
+```zig
+const out = try struct_lib.transform(allocator, data, spec);
+```
+
+### Bridging to/from `std.json`
+
+```zig
+const v = try struct_lib.fromStdJson(allocator, std_json_value);
+const j = try struct_lib.toStdJson(allocator, v);
+```
+
+
+## Reference
+
+Source: [`src/struct.zig`](./src/struct.zig).
+
+### Core type
+
+```zig
+pub const JsonValue = union(enum) {
+    null,
+    bool: bool,
+    integer: i64,
+    float: f64,
+    string: []const u8,
+    number_string: []const u8,
+    object: *MapRef,        // pointer-stable map
+    array: *ListRef,        // pointer-stable list
+    function: JsonFunc,
+};
+```
+
+`MapRef` and `ListRef` are heap-allocated wrappers so that mutations
+are visible to every holder.  This preserves the canonical
+"reference-stable" semantics.
+
+### Major functions
+
+```zig
+pub fn walk(allocator, node, apply, opts) anyerror!JsonValue
+pub fn merge(allocator, list, maxdepth) anyerror!JsonValue
+pub fn getpath(allocator, path, store) anyerror!JsonValue
+pub fn setpath(allocator, store, path, val) anyerror!JsonValue
+pub fn injectVal(allocator, val, store, inj_opt) anyerror!JsonValue
+pub fn transform(allocator, data, spec) anyerror!JsonValue
+```
+
+Predicates and minor utilities follow the canonical naming
+(lowercase): `isnode`, `ismap`, `islist`, `iskey`, `isempty`,
+`isfunc`, `getprop`, `setprop`, `keysof`, `haskey`, `items`,
+`stringify`, `jsonify`, etc.
+
+### `std.json` interop
+
+```zig
+pub fn fromStdJson(allocator, jv: StdJsonValue) anyerror!JsonValue
+pub fn toStdJson(allocator, v: JsonValue) anyerror!StdJsonValue
+```
+
+Use these at API boundaries (parsing input, returning to a JSON
+encoder) and stay in `JsonValue` everywhere else.
+
+
+## Explanation
+
+### Why a custom `JsonValue` rather than `std.json.Value`
+
+Zig's stdlib `std.json.Value` is a value type: assignment copies and
+nested mutation is awkward.  The canonical algorithm assumes
+reference-stable lists and maps, so the port wraps containers in
+heap-allocated `MapRef` / `ListRef` structs.  Conversion functions
+bridge to and from `std.json.Value` at the boundary.
+
+### Allocator threaded through every call
+
+Idiomatic Zig: every function that may allocate takes an
+`Allocator`.  Callers control lifetime explicitly.  Errors propagate
+through `!` returns.
+
+### Status
+
+In progress.  Coverage of the canonical API is broad (all major
+subsystems present) but the test corpus pass rate is being raised.
+See [`../REPORT.md`](../REPORT.md) for the latest status.
+
+
+## Build and test
+
+```bash
+cd zig
+zig build test
+```
+
+Tests in [`test/`](./test/) consume fixtures from
+[`../build/test/`](../build/test/).


### PR DESCRIPTION
## Summary

This PR adds extensive documentation for the `struct` library, establishing a unified documentation framework across the canonical TypeScript implementation and all language ports (JavaScript, Python, Go, PHP, Ruby, Lua, C#, Zig, Java, and C++).

## Key Changes

- **Top-level README overhaul**: Expanded from minimal description to comprehensive guide including:
  - Detailed motivation explaining why `struct` solves cross-language data manipulation challenges
  - Conceptual framework (nodes, keys, paths, stores, specs, injections, sentinels)
  - Quick start examples in multiple languages
  - Common recipes (path lookup, merging, transforms, validation)
  - Language-neutral API reference
  - Documentation map following the Diataxis framework (Tutorial, How-to, Reference, Explanation)
  - Status matrix for all 10 language implementations

- **Per-language documentation**: Added `DOCS.md` files for each language port:
  - **TypeScript** (`ts/DOCS.md`): Canonical reference implementation documentation
  - **JavaScript** (`js/DOCS.md`): Runtime-identical plain JS port
  - **Python** (`py/DOCS.md`): Full-parity Python port with language-specific notes
  - **Go** (`go/DOCS.md`): Full-parity Go port with PascalCase naming conventions
  - **PHP** (`php/DOCS.md`): Full-parity PHP port with static method API
  - **Ruby** (`rb/DOCS.md`): Full-parity Ruby port with module-based API
  - **Lua** (`lua/DOCS.md`): Full-parity Lua port with table-based implementation
  - **C#** (`cs/DOCS.md`): In-progress .NET port with nullable reference types
  - **Zig** (`zig/DOCS.md`): In-progress Zig port with allocator-based API
  - **Java** (`java/DOCS.md`): Partial Java port (basic utilities only)
  - **C++** (`cpp/DOCS.md`): Partial C++ port (header-only, nlohmann/json based)

## Notable Implementation Details

- Each language documentation follows the Diataxis framework consistently: Tutorial (installation + first example), How-to recipes, Reference (API signatures), and Explanation (language-specific semantics)
- Documentation clearly marks implementation status (Canonical, Complete, In progress, Partial)
- Language-specific sections explain semantic differences (e.g., `null` vs `undefined` vs "absent", reference vs value semantics, naming conventions)
- Cross-references between top-level README and per-language docs enable navigation
- API signatures shown in language-native syntax with consistent semantic mapping to canonical TypeScript
- Test status and known issues documented for each port

https://claude.ai/code/session_01Lwd8wbZwbsi1CPXgiNXSN7