### PR TITLE
Add complete Rust port of Struct library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,22 @@ jobs:
         working-directory: ./php
         run: vendor/bin/phpunit
 
+  test-rs:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        working-directory: ./rs
+        run: cargo build --all-targets
+      - name: Run tests
+        working-directory: ./rs
+        run: cargo test
+
   test-cs:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ cs/tests/corpus-scoreboard.json
 cs/tests/bin/
 cs/tests/obj/
 
+# Rust (rs port)
+rs/target/
+rs/Cargo.lock
+

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 #   make inspect       — show version info for all languages
 #   make clean         — clean all build artifacts
 
-LANGS = ts js py go rb php lua zig java
+LANGS = ts js py go rb php lua zig java rs
 
 .PHONY: all inspect build test clean reset
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ syntax), and language-specific notes:
 | PHP        | Complete   | [`php/README.md`](./php/README.md)    |
 | Ruby       | Complete   | [`rb/README.md`](./rb/README.md)      |
 | Lua        | Complete   | [`lua/README.md`](./lua/README.md)    |
+| Rust       | Complete   | [`rs/README.md`](./rs/README.md)      |
 | C#         | In progress| [`cs/README.md`](./cs/README.md)      |
 | Zig        | In progress| [`zig/README.md`](./zig/README.md)    |
 | Java       | Partial    | [`java/README.md`](./java/README.md)  |

--- a/REPORT.md
+++ b/REPORT.md
@@ -16,7 +16,7 @@
 | **php** | 46 | 15 | 2 | 82/82 pass | Complete |
 | **rb** | 40+ | 15 | 2 | 75/75 pass | Complete |
 | **lua** | 40+ | 15 | 2 | 75/75 pass | Complete |
-| **rs** | 40+ | 15 | 2 | 1122/1122 corpus | Complete |
+| **rs** | 40+ | 15 | 2 | 1187/1187 corpus | Complete |
 | **java** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
 | **cpp** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
 | **cs** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
@@ -26,7 +26,7 @@
 reference-stable nodes via the `indexmap` crate, `Value::Noval` vs `Value::Null`
 kept distinct. All 11 transform commands, all 15 validate checkers, all 4 select
 operators, the `Injection` state machine, and the `primary.check` SDK test pass
-(`cargo test` → 1122 corpus checks; `cargo clippy` clean). See
+(`cargo test` → 1187 corpus checks; `cargo clippy` clean). See
 [rs/PLAN.md](./rs/PLAN.md) for the porting plan / challenge analysis and
 [rs/NOTES.md](./rs/NOTES.md) for the decisions.
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -16,9 +16,19 @@
 | **php** | 46 | 15 | 2 | 82/82 pass | Complete |
 | **rb** | 40+ | 15 | 2 | 75/75 pass | Complete |
 | **lua** | 40+ | 15 | 2 | 75/75 pass | Complete |
+| **rs** | 40+ | 15 | 2 | 1122/1122 corpus | Complete |
 | **java** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
 | **cpp** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
 | **cs** | 40 | 15 | 2 | 1178/1178 corpus | Complete |
+
+\*\* Rust: full TS-canonical parity. Idiomatic `snake_case` API (`get_path`,
+`is_node`, …; see `rs/README.md` for the name table), `Rc<RefCell>`
+reference-stable nodes via the `indexmap` crate, `Value::Noval` vs `Value::Null`
+kept distinct. All 11 transform commands, all 15 validate checkers, all 4 select
+operators, the `Injection` state machine, and the `primary.check` SDK test pass
+(`cargo test` → 1122 corpus checks; `cargo clippy` clean). See
+[rs/PLAN.md](./rs/PLAN.md) for the porting plan / challenge analysis and
+[rs/NOTES.md](./rs/NOTES.md) for the decisions.
 
 \*\* Java, C++ and C#: full TS-canonical parity. Injection state machine,
 `SKIP`/`DELETE` sentinels, mode constants, all 11 transform commands

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "voxgig-struct"
+version = "0.1.0"
+edition = "2021"
+description = "Uniform JSON-shaped data structure manipulations — Rust port of @voxgig/struct"
+license = "MIT"
+repository = "https://github.com/voxgig/struct"
+keywords = ["voxgig", "data", "struct", "structure", "json"]
+
+[lib]
+name = "voxgig_struct"
+path = "src/lib.rs"
+
+[dependencies]
+indexmap = "2"
+regex = "1"
+once_cell = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/rs/Makefile
+++ b/rs/Makefile
@@ -1,0 +1,21 @@
+.PHONY: inspect build test clean reset
+
+inspect:
+	@echo "Rust toolchain:"
+	@rustc --version
+	@cargo --version
+	@echo ""
+	@echo "Project version:"
+	@grep '^version' Cargo.toml | head -1
+
+build:
+	cargo build
+
+test:
+	cargo test
+
+clean:
+	cargo clean
+
+reset: clean
+	rm -f Cargo.lock

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -62,10 +62,24 @@ checks). `cargo clippy` is clean.
 ## Caveats
 
 - `T_symbol` / `T_instance` constants exist for parity but are never returned by
-  `typify` (no JSON-shaped Rust analog). User-supplied `$APPLY` functions and
-  user formatters in `$FORMAT` are best-effort — the corpus only exercises named
-  formatters and the `$APPLY` error paths, so the exact argument order for those
-  callables isn't pinned down.
+  `typify` — `Value` has no Symbol/Instance/BigInt variant (no JSON-shaped Rust
+  analog), so the `minor-edge-typify` assertions about those are unportable in
+  principle.
+- **Function values in data** all use one signature, `Fn(&Inj, &Value, &str,
+  &Value) -> Value` (see the table in [`README.md`](./README.md) "Function
+  values"). It's exact for transform/validate/select handlers and the thunks;
+  for `$APPLY`, a user `$FORMAT` formatter, and a callable `get_elem` `alt` it
+  differs from the dynamic TS shapes — the resolved value always arrives as the
+  `val` argument, `store` as `store`, the injection as `inj` (TS's `$APPLY`
+  passes `(value, store, inj)` positionally; a TS user formatter also gets
+  `key`/`parent`/`path`). All three paths are unit-tested (`function_values` in
+  `tests/corpus.rs`); the corpus itself can't exercise them (it's JSON).
+- `get_elem(list, key, alt)` *does* invoke a callable `alt` when the element is
+  absent (matching the canonical `alt()`). `getdef`/`getprop` don't — the
+  canonical doesn't either.
+- Number→string at extreme magnitudes and JS's integer-key reordering in
+  `JSON.stringify` (see "Key decisions") are documented JS-fidelity gaps; the
+  corpus doesn't reach them.
 - The `primary.check` SDK test uses a minimal mock SDK in `tests/corpus.rs`
   (mirroring `ts/test/sdk.ts`): `check(ctx)` returns
   `{zed: 'ZED' + (opts.foo ?? '') + '_' + (ctx.meta?.bar ?? '0')}`. There's no

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -6,11 +6,9 @@ The full challenge analysis and the original phased roadmap live in
 
 ## Status
 
-The library is **functionally complete** against the shared corpus: all eight
-`struct/*` test files pass (`cargo test` → 1120 checks). The only thing not
-ported is the top-level `primary` SDK-integration test (the mock client /
-utility / `makeContext` harness — cf. `go/testutil/`), which exercises an
-example SDK *built on* `struct`, not `struct` itself.
+**Complete** against the shared corpus: all eight `struct/*` test files plus
+the top-level `primary.check` SDK-integration test pass (`cargo test` → 1122
+checks). `cargo clippy` is clean.
 
 | Subsystem | State | Corpus |
 |---|---|---|
@@ -23,8 +21,8 @@ example SDK *built on* `struct`, not `struct` itself.
 | `transform` + all 11 commands (`$DELETE`, `$COPY`, `$KEY`, `$ANNO`, `$MERGE`, `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY`; `$META` recognised) + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks + `checkPlacement`/`injectorArgs`/`injectChild` + `FORMATTER` | done | `transform.*` ✓ |
 | `validate` + all 15 checkers (`$STRING`, `$NUMBER`/`$INTEGER`/`$DECIMAL`/`$BOOLEAN`/`$NULL`/`$NIL`/`$MAP`/`$LIST`/`$FUNCTION`/`$INSTANCE` via `validate_TYPE`, `$ANY`, `$CHILD`, `$ONE`, `$EXACT`) + `_validation` (modify hook) + `_validatehandler` + `_invalidTypeMsg` + `$OPEN` open-objects | done | `validate.*` ✓ |
 | `select` + operators (`$AND`, `$OR`, `$NOT`, `$GT`, `$LT`, `$GTE`, `$LTE`, `$LIKE`) | done | `select.*` ✓ |
-| Corpus test runner (`tests/corpus.rs`) | covers all `struct/*` slices (1120 checks) | — |
-| Top-level `primary` / SDK tests (mock client / `makeContext`) | not ported (out of scope — example SDK, not the library) | — |
+| Top-level `primary.check` (mock SDK: `check(ctx)` + client options) | done | `primary.check` ✓ |
+| Corpus test runner (`tests/corpus.rs`) | covers the full `test.json` (1122 checks) | — |
 
 ## Key decisions (see PLAN.md for the reasoning)
 
@@ -61,12 +59,14 @@ example SDK *built on* `struct`, not `struct` itself.
 - **`$WHEN`** uses `std::time::SystemTime` + a hand-rolled ISO-8601 UTC formatter (no
   `chrono`/`time` dependency).
 
-## Not ported
+## Caveats
 
-- The top-level `primary.check` SDK-integration test (mock client / utility /
-  `makeContext`, cf. `ts/test/sdk.ts` + `ts/test/utility/`). This is an example
-  SDK that uses `struct`, not part of the library.
 - `T_symbol` / `T_instance` constants exist for parity but are never returned by
-  `typify` (no JSON-shaped Rust analog); user-supplied `$APPLY` functions and
-  user formatters in `$FORMAT` are best-effort (the corpus only exercises named
-  formatters and the `$APPLY` error paths).
+  `typify` (no JSON-shaped Rust analog). User-supplied `$APPLY` functions and
+  user formatters in `$FORMAT` are best-effort — the corpus only exercises named
+  formatters and the `$APPLY` error paths, so the exact argument order for those
+  callables isn't pinned down.
+- The `primary.check` SDK test uses a minimal mock SDK in `tests/corpus.rs`
+  (mirroring `ts/test/sdk.ts`): `check(ctx)` returns
+  `{zed: 'ZED' + (opts.foo ?? '') + '_' + (ctx.meta?.bar ?? '0')}`. There's no
+  full `makeContext`/client framework — the corpus doesn't need one.

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -1,0 +1,68 @@
+# Rust Implementation Notes
+
+Port of the canonical TypeScript implementation (`ts/src/StructUtility.ts`).
+Design rationale and the full challenge analysis live in [`PLAN.md`](./PLAN.md);
+this file records the concrete decisions and the current state.
+
+## Status
+
+| Subsystem | State | Corpus |
+|---|---|---|
+| Value type, type bit-flags, mode flags, sentinels, jsnum coercions | done | — |
+| Minor utilities (`typename`, `typify`, predicates, `getprop`/`getelem`/`setprop`/`delprop`, `keysof`/`items`/`haskey`, `flatten`/`filter`, `escre`/`escurl`/`join`, `jsonify`/`stringify`/`pathify`/`clone`, `size`/`slice`/`pad`, `jm`/`jt`, `getdef`/`strkey`) | done | `minor.*` ✓ |
+| `walk` | done | `walk.basic` ✓ |
+| `merge` | done (walk-based, `Rc<RefCell>` scratch vectors) | `merge.cases` / `merge.array` / `merge.integrity` / `merge.basic` ✓ |
+| `getpath` / `setpath` | done (incl. relative `..` ascents, `$KEY`/`$GET:`/`$REF:`/`$META:`, `$$` escape, meta-path `$=`/`$~`, custom handler) | `getpath.basic` / `getpath.relative` / `getpath.special` / `getpath.handler` ✓ |
+| `inject`, `transform` (+ 11 commands), `validate` (+ 15 checkers), `select` (+ operators) | **staged** — `unimplemented!()` stubs pointing at `PLAN.md`; the `Injection` state machine, `InjectDef`, the default handler, and the structural plumbing are in place | not yet wired |
+| Corpus test runner (`tests/corpus.rs`) | covers the implemented subsets (712 checks) | — |
+| Top-level `primary` / SDK tests (mock client / `makeContext`) | not started | — |
+
+Running `cargo test` exercises the implemented corpus subsets.
+
+## Key decisions (see PLAN.md for the reasoning)
+
+- **`Value` enum** with `Rc<RefCell<Vec<Value>>>` lists, `Rc<RefCell<IndexMap<String, Value>>>`
+  maps (insertion-ordered via the `indexmap` crate), `Noval` (TS `undefined`) distinct
+  from `Null` (JSON null), `Func(Rc<dyn Fn(&Inj, &Value, &str, &Value) -> Value>)`, and
+  `Sentinel(&'static Sentinel)` (SKIP / DELETE, pointer identity).
+- **Single numeric variant `Num(f64)`** — integer-ness derived via `f.fract() == 0.0`
+  (`Number.isInteger(2.0) === true`). JS coercions (`+x`, `Number(x)`, `String(x)`,
+  `n | 0`) live in `value.rs` as `js_to_number` / `js_string` / `js_to_int32`.
+  Known gap: Rust `{}` on very large/small magnitudes doesn't switch to exponent
+  notation like JS (`1e21` → `"1000000000000000000000"` vs `"1e+21"`); not exercised
+  by the corpus.
+- **idiomatic `snake_case`** public API (`get_path`, `is_node`, `set_prop`, `esc_re`, …);
+  see the TS→Rust name table in [`README.md`](./README.md). No `#![allow(non_snake_case)]`.
+  Internal `$NAME` handlers keep their canonical names for audit comparability.
+- **`undefined` vs `null`**: `Value::Noval` vs `Value::Null`, never collapsed and never
+  represented by a sentinel string. The corpus runner uses the `__NULL__` / `__UNDEF__`
+  / `__EXISTS__` marker strings exactly as `ts/test/runner.ts` does.
+- **`merge`** is implemented walk-based to track the canonical; the `cur`/`dst` scratch
+  vectors are `Rc<RefCell<Vec<Value>>>` (two `FnMut` callbacks can't both hold `&mut` to
+  the same `Vec`). Result is `list[0]` mutated in place, as the canonical requires.
+- **`walk`** uses push/pop path backtracking (not the canonical's reusable array pool);
+  callbacks are `&mut dyn FnMut(&Value, &Value, &Value, &[String]) -> Value` with `key`
+  = `Noval` at the root and a `Str` for every descendant.
+- **`Injection`** is `Rc<RefCell<Injection>>` (`Inj`) because the inject machinery keeps
+  live mutable back-references (`prior`) — see PLAN.md §9. The borrow discipline (PLAN.md
+  §3) — accessors return owned `Value`s, never leak a `Ref`/`RefMut` guard across a call —
+  is the rule that keeps `RefCell` from panicking.
+- **`transform` / `validate`** return `Result<Value, StructError>` (the `throw new Error`
+  case becomes `Err`); the infallible utilities return `Value`.
+- **`escre`** does regex-metachar escaping via a closure replacement (`$&` → `format!("\\{}",
+  &caps[0])`); `escurl` is `encodeURIComponent` hand-rolled over UTF-8 bytes (not escaping
+  `A-Za-z0-9-_.!~*'()`).
+
+## What's not done / next
+
+- `inject` + the three-phase child loop + `_injectstr` (full-match vs partial, `$BT`/`$DS`
+  escapes, `$NAME999` transform-name syntax).
+- `transform` + the 11 commands (`$DELETE`/`$COPY`/`$KEY`/`$ANNO`/`$META`/`$MERGE`/`$EACH`/
+  `$PACK`/`$REF`/`$FORMAT`/`$APPLY`), `checkPlacement`/`injectorArgs`/`injectChild`, the
+  `FORMATTER` table. The `prior.keyI--` in `$REF`/`injectChild` is the studied exception
+  (PLAN.md §9 item 3).
+- `validate` + the 15 checkers, `_validation`/`_validatehandler`, `$OPEN` open-object
+  handling, `_invalidTypeMsg` text.
+- `select` + `$AND`/`$OR`/`$NOT`/`$GT`/`$LT`/`$GTE`/`$LTE`/`$LIKE`.
+- The top-level `primary` SDK tests (mock client / utility / `makeContext`; cf.
+  `go/testutil/`).

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -7,7 +7,7 @@ The full challenge analysis and the original phased roadmap live in
 ## Status
 
 **Complete** against the shared corpus: all eight `struct/*` test files plus
-the top-level `primary.check` SDK-integration test pass (`cargo test` → 1122
+the top-level `primary.check` SDK-integration test pass (`cargo test` → 1187
 checks). `cargo clippy` is clean.
 
 | Subsystem | State | Corpus |
@@ -22,7 +22,7 @@ checks). `cargo clippy` is clean.
 | `validate` + all 15 checkers (`$STRING`, `$NUMBER`/`$INTEGER`/`$DECIMAL`/`$BOOLEAN`/`$NULL`/`$NIL`/`$MAP`/`$LIST`/`$FUNCTION`/`$INSTANCE` via `validate_TYPE`, `$ANY`, `$CHILD`, `$ONE`, `$EXACT`) + `_validation` (modify hook) + `_validatehandler` + `_invalidTypeMsg` + `$OPEN` open-objects | done | `validate.*` ✓ |
 | `select` + operators (`$AND`, `$OR`, `$NOT`, `$GT`, `$LT`, `$GTE`, `$LTE`, `$LIKE`) | done | `select.*` ✓ |
 | Top-level `primary.check` (mock SDK: `check(ctx)` + client options) | done | `primary.check` ✓ |
-| Corpus test runner (`tests/corpus.rs`) | covers the full `test.json` (1122 checks) | — |
+| Corpus test runner (`tests/corpus.rs`) | covers the full `test.json` (1187 checks) | — |
 
 ## Key decisions (see PLAN.md for the reasoning)
 

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -1,25 +1,30 @@
 # Rust Implementation Notes
 
 Port of the canonical TypeScript implementation (`ts/src/StructUtility.ts`).
-Design rationale and the full challenge analysis live in [`PLAN.md`](./PLAN.md);
-this file records the concrete decisions and the current state.
+The full challenge analysis and the original phased roadmap live in
+[`PLAN.md`](./PLAN.md).
 
 ## Status
 
+The library is **functionally complete** against the shared corpus: all eight
+`struct/*` test files pass (`cargo test` → 1120 checks). The only thing not
+ported is the top-level `primary` SDK-integration test (the mock client /
+utility / `makeContext` harness — cf. `go/testutil/`), which exercises an
+example SDK *built on* `struct`, not `struct` itself.
+
 | Subsystem | State | Corpus |
 |---|---|---|
-| Value type, type bit-flags, mode flags, sentinels, jsnum coercions | done | — |
+| `Value` type, type bit-flags, mode flags, sentinels, jsnum coercions | done | — |
 | Minor utilities (`typename`, `typify`, predicates, `getprop`/`getelem`/`setprop`/`delprop`, `keysof`/`items`/`haskey`, `flatten`/`filter`, `escre`/`escurl`/`join`, `jsonify`/`stringify`/`pathify`/`clone`, `size`/`slice`/`pad`, `jm`/`jt`, `getdef`/`strkey`) | done | `minor.*` ✓ |
 | `walk` | done | `walk.basic` ✓ |
-| `merge` | done (walk-based, `Rc<RefCell>` scratch vectors) | `merge.cases` / `merge.array` / `merge.integrity` / `merge.basic` ✓ |
-| `getpath` / `setpath` | done (incl. relative `..` ascents, `$KEY`/`$GET:`/`$REF:`/`$META:`, `$$` escape, meta-path `$=`/`$~`, custom handler) | `getpath.basic` / `getpath.relative` / `getpath.special` / `getpath.handler` ✓ |
-| `Injection` (state machine: `descend`/`child`/`setval`), `inject`, `_injectstr`, `_injecthandler` | done | `inject.basic` / `inject.string` / `inject.deep` ✓ |
-| `transform` + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks + `$COPY`/`$DELETE`/`$KEY`/`$ANNO`/`$MERGE` commands, `checkPlacement`, `injectorArgs` | done | `transform.basic` / `transform.paths` / `transform.cmds` / `transform.modify` ✓ |
-| `transform` structural commands: `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY` (+ `injectChild`, `FORMATTER`); `validate` (+ 15 checkers); `select` (+ operators) | **staged** — `$EACH`/`$PACK`/etc. registered as error-pushing stubs; `validate`/`select` are `unimplemented!()` pointing at `PLAN.md` | not yet wired |
-| Corpus test runner (`tests/corpus.rs`) | covers the implemented subsets (830 checks) | — |
-| Top-level `primary` / SDK tests (mock client / `makeContext`) | not started | — |
-
-Running `cargo test` exercises the implemented corpus subsets.
+| `merge` | done (walk-based, `Rc<RefCell>` scratch vectors) | `merge.*` ✓ |
+| `getpath` / `setpath` | done | `getpath.*` ✓ |
+| `Injection` state machine, `inject`, `_injectstr`, `_injecthandler` | done | `inject.*` ✓ |
+| `transform` + all 11 commands (`$DELETE`, `$COPY`, `$KEY`, `$ANNO`, `$MERGE`, `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY`; `$META` recognised) + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks + `checkPlacement`/`injectorArgs`/`injectChild` + `FORMATTER` | done | `transform.*` ✓ |
+| `validate` + all 15 checkers (`$STRING`, `$NUMBER`/`$INTEGER`/`$DECIMAL`/`$BOOLEAN`/`$NULL`/`$NIL`/`$MAP`/`$LIST`/`$FUNCTION`/`$INSTANCE` via `validate_TYPE`, `$ANY`, `$CHILD`, `$ONE`, `$EXACT`) + `_validation` (modify hook) + `_validatehandler` + `_invalidTypeMsg` + `$OPEN` open-objects | done | `validate.*` ✓ |
+| `select` + operators (`$AND`, `$OR`, `$NOT`, `$GT`, `$LT`, `$GTE`, `$LTE`, `$LIKE`) | done | `select.*` ✓ |
+| Corpus test runner (`tests/corpus.rs`) | covers all `struct/*` slices (1120 checks) | — |
+| Top-level `primary` / SDK tests (mock client / `makeContext`) | not ported (out of scope — example SDK, not the library) | — |
 
 ## Key decisions (see PLAN.md for the reasoning)
 
@@ -46,26 +51,22 @@ Running `cargo test` exercises the implemented corpus subsets.
   callbacks are `&mut dyn FnMut(&Value, &Value, &Value, &[String]) -> Value` with `key`
   = `Noval` at the root and a `Str` for every descendant.
 - **`Injection`** is `Rc<RefCell<Injection>>` (`Inj`) because the inject machinery keeps
-  live mutable back-references (`prior`) — see PLAN.md §9. The borrow discipline (PLAN.md
-  §3) — accessors return owned `Value`s, never leak a `Ref`/`RefMut` guard across a call —
-  is the rule that keeps `RefCell` from panicking.
+  live mutable back-references (`prior`) — e.g. `$REF`/`injectChild` mutate `inj.prior.key_i`.
+  The borrow discipline (PLAN.md §3) — accessors return owned `Value`s, never leak a
+  `Ref`/`RefMut` guard across a call — is the rule that keeps `RefCell` from panicking.
 - **`transform` / `validate`** return `Result<Value, StructError>` (the `throw new Error`
   case becomes `Err`); the infallible utilities return `Value`.
-- **`escre`** does regex-metachar escaping via a closure replacement (`$&` → `format!("\\{}",
-  &caps[0])`); `escurl` is `encodeURIComponent` hand-rolled over UTF-8 bytes (not escaping
-  `A-Za-z0-9-_.!~*'()`).
+- **`escre`** does regex-metachar escaping via a closure replacement; `escurl` is
+  `encodeURIComponent` hand-rolled over UTF-8 bytes (not escaping `A-Za-z0-9-_.!~*'()`).
+- **`$WHEN`** uses `std::time::SystemTime` + a hand-rolled ISO-8601 UTC formatter (no
+  `chrono`/`time` dependency).
 
-## What's not done / next
+## Not ported
 
-- The structural transform commands: `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY` (+
-  `injectChild`, the `FORMATTER` table). These build the parallel data structures and
-  recurse with adjusted injection state; the `prior.keyI--` in `$REF`/`injectChild` is the
-  studied exception (PLAN.md §9 item 3). Currently registered as error-pushing stubs so
-  `transform` with those commands fails cleanly rather than crashing.
-- `$META` transform command (the `$=`/`$~` meta-path syntax in `getpath` is done; the
-  `$META` *command* and `_validatehandler`'s meta handling are not).
-- `validate` + the 15 checkers, `_validation`/`_validatehandler`, `$OPEN` open-object
-  handling, `_invalidTypeMsg` text.
-- `select` + `$AND`/`$OR`/`$NOT`/`$GT`/`$LT`/`$GTE`/`$LTE`/`$LIKE`.
-- The top-level `primary` SDK tests (mock client / utility / `makeContext`; cf.
-  `go/testutil/`).
+- The top-level `primary.check` SDK-integration test (mock client / utility /
+  `makeContext`, cf. `ts/test/sdk.ts` + `ts/test/utility/`). This is an example
+  SDK that uses `struct`, not part of the library.
+- `T_symbol` / `T_instance` constants exist for parity but are never returned by
+  `typify` (no JSON-shaped Rust analog); user-supplied `$APPLY` functions and
+  user formatters in `$FORMAT` are best-effort (the corpus only exercises named
+  formatters and the `$APPLY` error paths).

--- a/rs/NOTES.md
+++ b/rs/NOTES.md
@@ -13,8 +13,10 @@ this file records the concrete decisions and the current state.
 | `walk` | done | `walk.basic` ✓ |
 | `merge` | done (walk-based, `Rc<RefCell>` scratch vectors) | `merge.cases` / `merge.array` / `merge.integrity` / `merge.basic` ✓ |
 | `getpath` / `setpath` | done (incl. relative `..` ascents, `$KEY`/`$GET:`/`$REF:`/`$META:`, `$$` escape, meta-path `$=`/`$~`, custom handler) | `getpath.basic` / `getpath.relative` / `getpath.special` / `getpath.handler` ✓ |
-| `inject`, `transform` (+ 11 commands), `validate` (+ 15 checkers), `select` (+ operators) | **staged** — `unimplemented!()` stubs pointing at `PLAN.md`; the `Injection` state machine, `InjectDef`, the default handler, and the structural plumbing are in place | not yet wired |
-| Corpus test runner (`tests/corpus.rs`) | covers the implemented subsets (712 checks) | — |
+| `Injection` (state machine: `descend`/`child`/`setval`), `inject`, `_injectstr`, `_injecthandler` | done | `inject.basic` / `inject.string` / `inject.deep` ✓ |
+| `transform` + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks + `$COPY`/`$DELETE`/`$KEY`/`$ANNO`/`$MERGE` commands, `checkPlacement`, `injectorArgs` | done | `transform.basic` / `transform.paths` / `transform.cmds` / `transform.modify` ✓ |
+| `transform` structural commands: `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY` (+ `injectChild`, `FORMATTER`); `validate` (+ 15 checkers); `select` (+ operators) | **staged** — `$EACH`/`$PACK`/etc. registered as error-pushing stubs; `validate`/`select` are `unimplemented!()` pointing at `PLAN.md` | not yet wired |
+| Corpus test runner (`tests/corpus.rs`) | covers the implemented subsets (830 checks) | — |
 | Top-level `primary` / SDK tests (mock client / `makeContext`) | not started | — |
 
 Running `cargo test` exercises the implemented corpus subsets.
@@ -55,12 +57,13 @@ Running `cargo test` exercises the implemented corpus subsets.
 
 ## What's not done / next
 
-- `inject` + the three-phase child loop + `_injectstr` (full-match vs partial, `$BT`/`$DS`
-  escapes, `$NAME999` transform-name syntax).
-- `transform` + the 11 commands (`$DELETE`/`$COPY`/`$KEY`/`$ANNO`/`$META`/`$MERGE`/`$EACH`/
-  `$PACK`/`$REF`/`$FORMAT`/`$APPLY`), `checkPlacement`/`injectorArgs`/`injectChild`, the
-  `FORMATTER` table. The `prior.keyI--` in `$REF`/`injectChild` is the studied exception
-  (PLAN.md §9 item 3).
+- The structural transform commands: `$EACH`, `$PACK`, `$REF`, `$FORMAT`, `$APPLY` (+
+  `injectChild`, the `FORMATTER` table). These build the parallel data structures and
+  recurse with adjusted injection state; the `prior.keyI--` in `$REF`/`injectChild` is the
+  studied exception (PLAN.md §9 item 3). Currently registered as error-pushing stubs so
+  `transform` with those commands fails cleanly rather than crashing.
+- `$META` transform command (the `$=`/`$~` meta-path syntax in `getpath` is done; the
+  `$META` *command* and `_validatehandler`'s meta handling are not).
 - `validate` + the 15 checkers, `_validation`/`_validatehandler`, `$OPEN` open-object
   handling, `_invalidTypeMsg` text.
 - `select` + `$AND`/`$OR`/`$NOT`/`$GT`/`$LT`/`$GTE`/`$LTE`/`$LIKE`.

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,14 +1,17 @@
 # Rust Port — Porting Plan & Challenge Analysis
 
-> Status: **implementation in progress.** The foundation (`Value` type,
-> constants, jsnum coercions), all minor utilities, `walk`, `merge`, and
-> `getpath`/`setpath` are implemented and pass their corpus slices (712
-> checks via `cargo test`). `inject` / `transform` / `validate` / `select`
-> are staged — the `Injection` state machine and plumbing are in place,
-> the bodies are `unimplemented!()` stubs pointing here. See
-> [`NOTES.md`](./NOTES.md) for the current state and [`README.md`](./README.md)
-> for the API. The rest of this document is the original challenge analysis
-> and roadmap — still the reference for the remaining work.
+> Status: **implementation in progress.** Done and corpus-tested (830
+> checks via `cargo test`): the foundation (`Value` type, constants, jsnum
+> coercions), all minor utilities, `walk`, `merge`, `getpath`/`setpath`,
+> the `Injection` state machine, `inject` / `_injectstr` / `_injecthandler`,
+> and `transform` with the `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks and the
+> `$COPY`/`$DELETE`/`$KEY`/`$ANNO`/`$MERGE` commands (`checkPlacement` /
+> `injectorArgs` included). Staged: the structural transform commands
+> (`$EACH`/`$PACK`/`$REF`/`$FORMAT`/`$APPLY` + `injectChild`/`FORMATTER`),
+> `validate` (+ 15 checkers), `select` (+ operators) — see
+> [`NOTES.md`](./NOTES.md). [`README.md`](./README.md) has the API. The
+> rest of this document is the original challenge analysis and roadmap —
+> still the reference for the remaining work.
 >
 > The canonical implementation is
 > [`ts/src/StructUtility.ts`](../ts/src/StructUtility.ts) (~3,135 lines);

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,17 +1,16 @@
 # Rust Port — Porting Plan & Challenge Analysis
 
-> Status: **implementation in progress.** Done and corpus-tested (830
-> checks via `cargo test`): the foundation (`Value` type, constants, jsnum
-> coercions), all minor utilities, `walk`, `merge`, `getpath`/`setpath`,
-> the `Injection` state machine, `inject` / `_injectstr` / `_injecthandler`,
-> and `transform` with the `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks and the
-> `$COPY`/`$DELETE`/`$KEY`/`$ANNO`/`$MERGE` commands (`checkPlacement` /
-> `injectorArgs` included). Staged: the structural transform commands
-> (`$EACH`/`$PACK`/`$REF`/`$FORMAT`/`$APPLY` + `injectChild`/`FORMATTER`),
-> `validate` (+ 15 checkers), `select` (+ operators) — see
-> [`NOTES.md`](./NOTES.md). [`README.md`](./README.md) has the API. The
-> rest of this document is the original challenge analysis and roadmap —
-> still the reference for the remaining work.
+> Status: **functionally complete.** All eight `struct/*` corpus files pass
+> (`cargo test` → 1120 checks): foundation (`Value` type, constants, jsnum
+> coercions), all minor utilities, `walk`, `merge`, `getpath`/`setpath`, the
+> `Injection` state machine, `inject` / `_injectstr` / `_injecthandler`,
+> `transform` (all 11 commands + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks +
+> `checkPlacement`/`injectorArgs`/`injectChild`/`FORMATTER`), `validate`
+> (all 15 checkers + `_validation` + `_validatehandler` + `$OPEN`), and
+> `select` (all operators). Not ported: the top-level `primary` SDK
+> integration test (an example SDK built on `struct`, not the library) — see
+> [`NOTES.md`](./NOTES.md). [`README.md`](./README.md) has the API. The rest
+> of this document is the original challenge analysis and roadmap.
 >
 > The canonical implementation is
 > [`ts/src/StructUtility.ts`](../ts/src/StructUtility.ts) (~3,135 lines);

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,16 +1,16 @@
 # Rust Port — Porting Plan & Challenge Analysis
 
-> Status: **functionally complete.** All eight `struct/*` corpus files pass
-> (`cargo test` → 1120 checks): foundation (`Value` type, constants, jsnum
+> Status: **complete.** The full shared corpus passes (`cargo test` → 1122
+> checks; `cargo clippy` clean): foundation (`Value` type, constants, jsnum
 > coercions), all minor utilities, `walk`, `merge`, `getpath`/`setpath`, the
 > `Injection` state machine, `inject` / `_injectstr` / `_injecthandler`,
 > `transform` (all 11 commands + `$BT`/`$DS`/`$WHEN`/`$SPEC` thunks +
 > `checkPlacement`/`injectorArgs`/`injectChild`/`FORMATTER`), `validate`
-> (all 15 checkers + `_validation` + `_validatehandler` + `$OPEN`), and
-> `select` (all operators). Not ported: the top-level `primary` SDK
-> integration test (an example SDK built on `struct`, not the library) — see
+> (all 15 checkers + `_validation` + `_validatehandler` + `$OPEN`), `select`
+> (all operators), and the `primary.check` SDK test (minimal mock SDK). See
 > [`NOTES.md`](./NOTES.md). [`README.md`](./README.md) has the API. The rest
-> of this document is the original challenge analysis and roadmap.
+> of this document is the original challenge analysis and roadmap that got
+> the port to this state.
 >
 > The canonical implementation is
 > [`ts/src/StructUtility.ts`](../ts/src/StructUtility.ts) (~3,135 lines);

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,8 +1,16 @@
 # Rust Port — Porting Plan & Challenge Analysis
 
-> Status: **planning only**. No code yet. This document examines what a
-> faithful Rust port of `@voxgig/struct` involves, where the friction
-> is, and how to lay the work out. The canonical implementation is
+> Status: **implementation in progress.** The foundation (`Value` type,
+> constants, jsnum coercions), all minor utilities, `walk`, `merge`, and
+> `getpath`/`setpath` are implemented and pass their corpus slices (712
+> checks via `cargo test`). `inject` / `transform` / `validate` / `select`
+> are staged — the `Injection` state machine and plumbing are in place,
+> the bodies are `unimplemented!()` stubs pointing here. See
+> [`NOTES.md`](./NOTES.md) for the current state and [`README.md`](./README.md)
+> for the API. The rest of this document is the original challenge analysis
+> and roadmap — still the reference for the remaining work.
+>
+> The canonical implementation is
 > [`ts/src/StructUtility.ts`](../ts/src/StructUtility.ts) (~3,135 lines);
 > the contract every port must satisfy is the shared corpus in
 > [`build/test/`](../build/test/) (`test.json`, compiled from the

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,6 +1,6 @@
 # Rust Port — Porting Plan & Challenge Analysis
 
-> Status: **complete.** The full shared corpus passes (`cargo test` → 1122
+> Status: **complete.** The full shared corpus passes (`cargo test` → 1187
 > checks; `cargo clippy` clean): foundation (`Value` type, constants, jsnum
 > coercions), all minor utilities, `walk`, `merge`, `getpath`/`setpath`, the
 > `Injection` state machine, `inject` / `_injectstr` / `_injecthandler`,

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -494,17 +494,48 @@ same `Rc`, not a fresh one.
 
 ## 12. Names and constants
 
-- Rust convention is `snake_case`. **Recommendation:** rename to
-  `get_path`, `get_prop`, `is_node`, `is_map`, `is_list`, `is_key`,
-  `is_empty`, `is_func`, `keys_of`, `str_key`, `has_key`, `set_path`,
-  `set_prop`, `del_prop`, `type_name`, `get_def`, `get_elem`, `jsonify`,
-  `stringify`, `pathify`, `clone`, `escre`, `escurl`, `join`, etc.,
-  and ship a "TS name → Rust name" table in `README.md` (the repo
-  README already does this kind of cross-language casing note). Run
-  `clippy` clean. *Alternative:* keep the canonical lowercase names with
-  `#![allow(non_snake_case)]` for maximum line-by-line comparability —
-  weigh "real Rust crate" vs "diff-able against TS". Pick one and be
-  consistent.
+**Decided: idiomatic Rust `snake_case` for the public API**, with a
+"TS name → Rust name" table in `README.md` (the top-level README already
+documents per-language casing — `getpath` in JS/Py/Lua/Rb/PHP, `GetPath`
+in Go/C#, `getPath` in Java — so a fourth, Rust-idiomatic convention is
+in keeping with how the project already works; Go, the closest sibling,
+went fully idiomatic `PascalCase` rather than mimicking TS). No
+`#![allow(non_snake_case)]` escape hatch; `clippy` runs clean. The
+transcription stays "human-comparable" via the name table and matching
+*structure*, not matching *identifiers*.
+
+Note that most canonical names are already lint-clean lowercase
+(`rustc`'s `non_snake_case` lint only fires on *uppercase* letters, so
+`getpath`/`typify`/`escre` would pass as-is) — but the API guidelines'
+`snake_case` means word-separated, so we add underscores at compound
+boundaries. Coined single words stay verbatim.
+
+| TS canonical | Rust |
+|---|---|
+| `typename` | `type_name` |
+| `getdef` | `get_def` |
+| `isnode` / `ismap` / `islist` / `iskey` / `isempty` / `isfunc` | `is_node` / `is_map` / `is_list` / `is_key` / `is_empty` / `is_func` |
+| `size` / `slice` / `pad` / `typify` | `size` / `slice` / `pad` / `typify` |
+| `getelem` / `getprop` / `setprop` / `delprop` | `get_elem` / `get_prop` / `set_prop` / `del_prop` |
+| `strkey` / `keysof` / `haskey` | `str_key` / `keys_of` / `has_key` |
+| `items` / `flatten` / `filter` | `items` / `flatten` / `filter` |
+| `escre` / `escurl` | `esc_re` / `esc_url` |
+| `join` / `jsonify` / `stringify` / `pathify` / `clone` | `join` / `jsonify` / `stringify` / `pathify` / `clone` |
+| `walk` / `merge` / `inject` / `transform` / `validate` / `select` | same |
+| `getpath` / `setpath` | `get_path` / `set_path` |
+| `jm` / `jt` | `jm` / `jt` (terse builders, kept verbatim) |
+| `checkPlacement` / `injectorArgs` / `injectChild` | `check_placement` / `injector_args` / `inject_child` |
+| `SKIP` / `DELETE` | `SKIP` / `DELETE` |
+| `T_any` … `T_node` (15) | `T_ANY` … `T_NODE` (Rust const = SCREAMING_SNAKE) |
+| `M_KEYPRE` / `M_KEYPOST` / `M_VAL` / `MODENAME` | `M_KEYPRE` / `M_KEYPOST` / `M_VAL` / `MODENAME` |
+| `StructUtility` (class) | `StructUtility` (struct/impl bundling the free fns) |
+| `Injection` / `Injector` / `WalkApply` / `Modify` (types) | same |
+
+Internal `$NAME` transform/validate/select handlers (`transform_COPY`,
+`validate_STRING`, `select_AND`, …) keep their canonical names — they're
+crate-private, so casing is moot, and matching them aids the audit.
+The `$DELETE`/`$COPY`/`$STRING`/`$AND`/… *spec tokens themselves* are
+data strings, unchanged in every port.
 - Type bit-flags: `1 << 31` overflows `i32` (the C++ port hit this too),
   so the bitfield type is **`u32`** (or `i64`). Constants: `T_ANY =
   (1u32 << 31) - 1`, `T_NOVAL = 1 << 30`, … down to `T_NODE`. Rust has
@@ -646,7 +677,7 @@ the relevant corpus slice at the end of each phase.
 | 2 | `merge` walk-callbacks → two `&mut`-capturing `FnMut`s | Borrow-checker-hostile as written. | Reimplement `merge` as direct recursion (§8 Option B); document the divergence. |
 | 3 | `Injection.prior` back-pointer + `inj.prior.keyI--` in `$REF`/`injectChild` | Can't safely hold `&mut` back-references; the decrement must be visible to the in-flight parent loop. | Pass mutable child-loop state down explicitly, re-reading `childinj.keyI`/`childinj.keys` (already the pattern in `inject`); treat `$REF`/`injectChild` as the studied exceptions (§9). Fallback: `Rc<RefCell<Injection>>` throughout. |
 | 4 | `Num(f64)` vs `enum N { Int, Float }` | Affects every numeric site; `f64` is more JS-faithful but less Rust-idiomatic; `Int/Float` needs normalisation rules. | `Num(f64)` + `is_integer`/`to_int32` helpers (§4); note the alternative. |
-| 5 | `snake_case` rename vs canonical names | "Real Rust crate" + clippy vs line-by-line comparability with TS. | `snake_case` + a TS→Rust name table in `README.md` (§12). |
+| 5 | API naming | "Real Rust crate" + clippy vs line-by-line comparability with TS. | **Decided:** idiomatic `snake_case` (`get_path`, `is_node`, …), no `allow(non_snake_case)`, with a TS→Rust name table in `README.md` (§12). |
 | 6 | `Rc<RefCell>` vs `Arc<Mutex>` (thread safety) | `Send`/`Sync` would touch every access site and add lock cost. | Single-threaded `Rc<RefCell>`; document "not thread-safe, like the JS canonical". Arc variant = out of scope. |
 | 7 | Number→string and large-magnitude exponent notation | Rust `{}` on `1e21` ≠ JS `"1e+21"`; `0.0000001` likewise. | Mostly used on small integer indices, so likely a non-issue; document as a known difference unless the corpus hits it. |
 | 8 | JS object integer-key reordering in `JSON.stringify` | `jsonify` could differ from canonical for maps with numeric-string keys. | Probably accept the `IndexMap`-order behaviour; note it; emulate only if the corpus demands. |

--- a/rs/PLAN.md
+++ b/rs/PLAN.md
@@ -1,0 +1,675 @@
+# Rust Port — Porting Plan & Challenge Analysis
+
+> Status: **planning only**. No code yet. This document examines what a
+> faithful Rust port of `@voxgig/struct` involves, where the friction
+> is, and how to lay the work out. The canonical implementation is
+> [`ts/src/StructUtility.ts`](../ts/src/StructUtility.ts) (~3,135 lines);
+> the contract every port must satisfy is the shared corpus in
+> [`build/test/`](../build/test/) (`test.json`, compiled from the
+> `*.jsonic` sources).
+
+---
+
+## 1. Goal and ground rules
+
+- **One API, one set of semantics.** The Rust port exposes the same 40
+  public functions, 2 sentinels, 15 type bit-flags, 3 mode flags, 11
+  transform commands, and 15 validate checkers as the TypeScript
+  canonical (see [`../README.md`](../README.md) and
+  [`../REPORT.md`](../REPORT.md)).
+- **The corpus is the spec.** Disagreement between the port and
+  `build/test/test.json` is a port bug, never a corpus bug. So a corpus
+  test runner is part of the deliverable, not an afterthought.
+- **Human-comparable where it's free, idiomatic where it isn't.** The TS
+  source keeps "functionally redundant" code so ports stay line-by-line
+  comparable. Rust's ownership model makes a 1:1 transcription
+  impossible in a few spots (`merge`'s walk-callbacks, the `walk` path
+  pool, optional/overloaded parameters). Diverge there, and record each
+  divergence in `NOTES.md` — the way `go/NOTES.md`, `php/NOTES.md`, and
+  `cpp/REFACTOR_PLAN.md` do.
+- **Not a rewrite of behaviour.** Quirks are deliberate: `stringify`
+  strips *all* `"`; `keysof` sorts list indices as strings; JSON `null`
+  is not `undefined`; lists are mutable and reference-stable. Reproduce
+  them, don't "fix" them.
+
+---
+
+## 2. The decision that drives everything: the in-memory value type
+
+Every other choice follows from how JSON-shaped data is represented in
+memory. This mirrors the analysis in
+[`cpp/REFACTOR_PLAN.md`](../cpp/REFACTOR_PLAN.md), adapted to Rust.
+
+### Recommendation
+
+```rust
+// sketch — not final
+pub enum Value {
+    Noval,                                  // TS `undefined` — property absent. NOT a scalar.
+    Null,                                   // JSON null — a real value, distinct from Noval.
+    Bool(bool),
+    Num(f64),                               // see §4 — one numeric kind, integer-ness derived
+    Str(String),
+    List(Rc<RefCell<Vec<Value>>>),          // reference-stable, mutable in place
+    Map(Rc<RefCell<IndexMap<String, Value>>>), // insertion-ordered, reference-stable
+    Func(Func),                             // callable values live in the data, see §6
+    Sentinel(&'static Sentinel),            // SKIP / DELETE — pointer identity
+}
+
+pub struct Sentinel { pub tag: &'static str }
+pub static SKIP: Sentinel = Sentinel { tag: "`$SKIP`" };
+pub static DELETE: Sentinel = Sentinel { tag: "`$DELETE`" };
+
+pub type Injector = Rc<dyn Fn(&mut Injection, &Value, &str, &Value) -> Value>;
+pub type Modify   = Rc<dyn Fn(&Value, &Value /*key*/, &Value /*parent*/, &mut Injection, &Value /*store*/)>;
+pub type WalkApply<'a> = &'a mut dyn FnMut(Option<&str>, &Value, &Value, &[String]) -> Value;
+pub enum Func { Injector(Injector), Modify(Modify) }   // or unify behind one closure type
+```
+
+### Why each piece
+
+1. **A custom enum, not `serde_json::Value`.** `serde_json::Value` has
+   no place for callables (the `$COPY`/`$EACH`/… injectors live *inside*
+   the `store` map alongside data and are looked up with `getprop`), no
+   sentinel identity that survives `clone`, and `Value::Map` is a
+   `BTreeMap`/`Map` that does not preserve insertion order. We keep
+   `serde_json` only as the *JSON-text parser* for loading the corpus
+   (and possibly as a serialise bridge), exactly as the C++ plan keeps
+   `nlohmann::json` only as a parse bridge.
+
+2. **`Rc<RefCell<…>>` for `List` and `Map` interiors.** The library's
+   core invariant (see [`../README.md`](../README.md) "Design notes" and
+   the `StructUtility.ts` header comment) is *"Lists are assumed to be
+   mutable and reference-stable."* `merge` builds its output by walking
+   and mutating nodes in place; `inject` mutates the cloned spec in
+   place; the `Injection` struct keeps `nodes` — a stack of ancestor
+   node *references* — and `setprop`/`delprop`/`setval` write through
+   them. JS gets this for free (objects/arrays are heap refs). Go and
+   PHP needed a `ListRef` wrapper; C++ uses `shared_ptr<List>`; Zig uses
+   heap-allocated `MapRef`/`ListRef`. Rust's equivalent is
+   `Rc<RefCell<_>>`: cheap `Rc`-clone "copies", shared mutation visible
+   to every holder, forked only by `clone()`.
+
+3. **`IndexMap` (the `indexmap` crate), not `HashMap`/`BTreeMap`.** TS
+   objects preserve insertion order, and `inject` depends on it: it
+   partitions a node's keys into "no `$`" then "`$`-bearing" (transform
+   commands run last), and the spec-clone that becomes the transform
+   *output* carries the spec's key order. `keysof` then *sorts* keys
+   explicitly where sorting is wanted. `IndexMap` gives us insertion
+   order to preserve and `.sort_keys()` / `keys().sorted()` where we
+   need it. (`BTreeMap` would be permanently sorted — wrong for output;
+   `HashMap` has no order at all.)
+
+4. **`Func` as a first-class variant.** `transform`'s `store` literally
+   contains `$COPY: transform_COPY`, `$WHEN: || iso_now()`,
+   `$SPEC: || origspec.clone()`, the `FORMATTER` closures, etc.
+   `getprop(store, "$COPY")` returns one; `isfunc` tests it; the inject
+   handler calls it. So `Value::Func` must exist. Closures that capture
+   environment go in `Rc<dyn Fn>`. There is no need for *function
+   equality* except inside `Value`'s `PartialEq` (used by
+   `validate_EXACT` and the test runner) — define `Func == Func` as
+   `Rc::ptr_eq` (or always `false`); it never matters in practice.
+
+5. **Distinct `Noval` and `Null`.** TS treats `undefined` (absent) and
+   `null` (JSON null) as different values and the corpus relies on it
+   (`getprop`/`getelem` "absent vs present-but-null", several validate
+   tests, the `$NIL` vs `$NULL` checkers). Rust can model this cleanly
+   with two variants — *do not* collapse them into `Option<Value>` and
+   *do not* use a `"__UNDEFINED__"` sentinel string the way PHP had to.
+   The corpus runner uses the marker strings `__NULL__`, `__UNDEF__`,
+   `__EXISTS__` to talk about these over the JSON wire (see
+   `ts/test/runner.ts`).
+
+6. **`Sentinel` by `&'static` reference.** `SKIP`/`DELETE` are compared
+   by identity (`SKIP === val`, `DELETE === val`). Two `static`
+   instances, compared with `std::ptr::eq`. `clone()` must short-circuit
+   on the `Sentinel` variant so identity survives a deep copy (TS does
+   the same via its `$REF:N` round-trip dance — we just skip the dance).
+
+7. **One numeric variant `Num(f64)`** — see §4 for the full argument.
+   Short version: JS has one number type; faithfulness beats Rust's
+   `i64` instinct here, and it sidesteps a `2.0`-vs-`2` parse mismatch
+   and `i64`-overflow corner cases. (Alternative: `enum N { Int(i64),
+   Float(f64) }` like the C++ plan — listed as an open question.)
+
+### Threading
+
+`Rc<RefCell>` is single-threaded. That matches the JS model the library
+is transcribed from, and it is the cheapest option. A `Send + Sync`
+variant would mean `Arc<Mutex<_>>` (or `RwLock`), which changes every
+single access site and adds lock overhead. **Recommendation:** ship the
+`Rc<RefCell>` version, document "not thread-safe — single-threaded data
+model, like the JS canonical" in `NOTES.md`, and treat an `Arc` variant
+as out of scope (open question §11).
+
+---
+
+## 3. The borrow-checker discipline (the thing most likely to bite)
+
+`RefCell` turns aliasing-with-mutation from a compile error into a
+runtime panic. A naive transcription of the canonical code *will*
+double-borrow. The rule that makes it work:
+
+> **Accessor functions return owned `Value`s. A `Ref`/`RefMut` guard
+> never outlives the smallest possible block, and is never held across a
+> call to anything that might touch the same cell.**
+
+Concretely:
+
+- `getprop` / `getelem`: `borrow()` the cell, clone the slot out
+  (`Value::clone` on a node is just an `Rc::clone` — cheap), drop the
+  borrow, return the owned `Value`. Never return `Ref<…>`.
+- `setprop` / `delprop` / `Injection::setval`: `borrow_mut()`, mutate,
+  drop. Take `&Value` for the parent (not `&mut`) — the mutation goes
+  through the `RefCell`, so the *handle* is shared-immutable while the
+  *contents* change. This is exactly how JS behaves.
+- `items` / `keysof`: collect into a fresh `Vec<(String, Value)>` /
+  `Vec<String>` and drop the borrow *before* the caller iterates — the
+  TS versions already return fresh arrays, so mirroring "snapshot then
+  iterate" is both faithful and panic-safe. `walk` and `inject` mutate
+  the node they're iterating; the snapshot is what makes that legal.
+- `Injection` holds `parent: Value`, `nodes: Vec<Value>`, `val: Value`,
+  `meta: Value` — all cheap (`Rc`-backed for nodes). It's passed
+  `&mut Injection`. When an injector needs to call the modify/handler
+  hook *that is stored on the injection* (`inj.modify(…, inj, …)`),
+  clone the `Rc<dyn Fn>` out first (`let m = inj.modify.clone()`), then
+  call `m(…, &mut inj, …)`. Same for `inj.handler`.
+
+This discipline is the price of the `Rc<RefCell>` design. It's
+manageable, but it's the part to write carefully and test hard.
+
+---
+
+## 4. Numbers: integer vs decimal
+
+TS: `typify` returns `T_integer` when `Number.isInteger(v)` (note
+`Number.isInteger(2.0) === true`), `T_decimal` otherwise, `T_noval` for
+`NaN`. `size(number)` is `Math.floor(v)`. `slice(number, …)` clamps to
+`[start, end-1]` with `Number.MIN/MAX_SAFE_INTEGER` defaults.
+`strkey(2.2) === "2"` (truncate). FORMATTER `integer` does `n | 0`
+(ToInt32 — wraps at 2³²!). `getelem` parses keys with `parseInt`.
+
+Two viable models:
+
+| | `Value::Num(f64)` (recommended) | `enum N { Int(i64), Float(f64) }` |
+|---|---|---|
+| JSON parse | `serde_json` literal `2.0` → f64 `2.0` → `is_integer()` true. No normalisation drama. | Must normalise: `2.0` literal should behave as integer (JS `JSON.parse("2.0")` → `2`). And `1e100` is "integer" in JS but doesn't fit `i64`. |
+| Fidelity to JS | Exact, including JS's own 2⁵³ precision ceiling. | Diverges at the `i64`/`f64` boundary. |
+| Rust ergonomics | Users must `as i64`. Slightly un-idiomatic. | Idiomatic. |
+| Effort | Lower. | Higher (normalisation rules everywhere). |
+
+**Recommendation:** `Num(f64)` with helpers `is_integer(f) -> bool`
+(= `f.is_finite() && f.fract() == 0.0`) and a JS-flavoured
+`to_int32(f)` for the FORMATTER. Document the choice. Carry the
+`Int/Float` split as a noted alternative.
+
+Either way you need faithful coercion helpers, because the canonical
+code leans on JS coercions that have no Rust stdlib equivalent:
+
+- `+x` (unary plus / `ToNumber`): `"12"`→12, `""`→0, `"  "`→0,
+  `"12abc"`→NaN, `true`→1, `null`→0, `[]`→0, `[5]`→5, `{}`→NaN. Used in
+  `setprop`/`delprop` (`let keyI = +key; if isNaN(keyI) { return }`).
+- `parseInt(x)`: lenient prefix parse, hex auto-detect (`"0x1f"`→31),
+  `"12abc"`→12, `"abc"`→NaN. Used in `getelem`, but always behind the
+  `/^[-0-9]+$/` guard, so a `str::parse::<i64>()` covers the live cases
+  (modulo pathological `"--5"`, `"5-5"` — likely untested).
+- `Number(x)`: like `+x` but used in FORMATTER `number`/`integer`.
+- `String(x)` / `"" + x`: JS number→string (`2.0`→`"2"`, `2.5`→`"2.5"`,
+  `1e21`→`"1e+21"` — Rust's `{}` gives `"1000000000000000000000"`,
+  a divergence at large magnitudes; `1e-7`→`"1e-7"` likewise). Mostly
+  used as `"" + index` where index is a small non-negative integer, so
+  the exotic cases are unlikely to surface in the corpus.
+
+Implement these as a small `jsnum` module; treat the exponential-
+notation stringification gap as a documented known-difference unless the
+corpus exercises it.
+
+---
+
+## 5. Regular expressions
+
+The canonical uses ~14 static JS regexes plus a couple built
+dynamically:
+
+- Static patterns are all plain enough for the `regex` crate:
+  `^[-0-9]+$`, the regex-metachar class, the URL-slash patterns,
+  ``^`\$REF:([0-9]+)`$``, `^([^$]+)\$([=~])(.+)$`, `\$\$`,
+  ``\`\$([A-Z]+)\``, ``^\`(\$[A-Z]+|[^`]*)[0-9]*\`$``, `\$BT`, `\$DS`,
+  ``\`([^`]+)\``. None use backreferences or lookaround, so Rust
+  `regex` is fine.
+- Dynamic: `join` builds `RegExp(sepre + "+$")` etc. from an *escaped*
+  separator — fine. `select`'s `$LIKE` does `RegExp(term)` on a
+  user-supplied string — Rust `regex` will reject some JS-isms; accept
+  that as a documented limitation.
+- The test runner itself uses `^/(.+)/$` to detect `/regex/` literals in
+  expected values — fine.
+
+Gotchas:
+
+- **Replacement string syntax.** JS `String.replace(re, repl)` uses
+  `$&` (whole match), `$1`, `$$`. Rust `regex` replacement uses `$0` /
+  `${0}` (whole match), `$1` / `${1}`, `$$` for a literal `$`, and `\`
+  is *not* special. So `escre`'s `replace(s, R_ESCAPE_REGEXP, "\\$&")`
+  becomes `re.replace_all(s, r"\${0}")` (a literal backslash then the
+  matched char). Write a tiny `replace(s, pat, repl)` wrapper that
+  matches the canonical `replace` helper's contract (it also stringifies
+  non-strings and maps `undefined`/`null` to `""` — see
+  `StructUtility.ts` `replace`).
+- **`g` flag.** The canonical uses `/…/g` for replace-all and a couple
+  of `.match()` calls without `/g`. Map to `replace_all` vs `captures` /
+  `find` accordingly.
+
+---
+
+## 6. Functions stored in data; closures with captured state
+
+- `Value::Func` carries `Rc<dyn Fn(&mut Injection, &Value, &str, &Value)
+  -> Value>` for injectors. `$WHEN` captures nothing but calls the
+  clock; `$SPEC: || origspec` captures the original spec; `FORMATTER`
+  entries are stateless closures; `select`'s `$AND`/`$OR`/`$NOT`/`$CMP`
+  call back into `validate` (which calls `transform` → `inject` → a
+  fresh `Injection`) — recursion through the public API is fine.
+- The `Modify` hook (`_validation`) is *stored on* the `Injection` and
+  *takes* the `Injection` — `inj.modify(val, key, parent, inj, store)`.
+  Clone the `Rc<dyn Fn>` out before calling (see §3). Same for
+  `inj.handler` (`_injecthandler` / `_validatehandler`).
+- `clone()` semantics: *"function and instance values are copied, not
+  cloned"* — i.e. `Rc::clone` the closure, deep-copy maps/lists into
+  fresh `Rc<RefCell>`s, copy scalars, preserve sentinel identity. Much
+  simpler than the TS `JSON.parse(JSON.stringify(…, $REF:N …))` trick —
+  no marker dance needed. Assumes acyclic data (so does TS; a cycle
+  stack-overflows in both).
+- One real awkwardness: `WalkApply` is a closure passed *into* `walk`,
+  and `merge` builds two of them (`before`, `after`) that both need
+  `&mut` access to the same `cur`/`dst` scratch vectors. See §8.
+
+---
+
+## 7. Optional parameters, overloads, and `Partial<Injection>`
+
+Rust has none of: default args, optional trailing args, overloads. The
+canonical leans on all three. Options per function:
+
+- `getprop(node, key, alt?)`, `getelem(list, key, alt?)`,
+  `getdef(val, alt)`: provide a 3-arg form `get_prop(node, key, alt)`
+  taking `alt: Value` (callers pass `Value::Noval` for the bare case),
+  plus a 2-arg convenience `get_prop2(node, key)` *or* take
+  `alt: impl Into<Value>` with a unit-ish impl. Note `getelem`'s `alt`
+  can be a *function* that gets called when the element is absent
+  (`0 < (T_function & typify(alt)) ? alt() : alt`) — keep that.
+- `slice(val, start?, end?, mutate?)`: 4-ary; pass `Option<i64>` /
+  `bool`. The numeric-input branch (clamp a number) and the
+  `mutate`-in-place branch both matter (`merge` calls
+  `slice(maxdepth ?? 32, 0)`; `transform_EACH` calls
+  `slice(inj.keys, 0, 1, true)`).
+- `items(val)` vs `items(val, apply)`: ship `items(val) ->
+  Vec<(String, Value)>`; callers do `.into_iter().map(apply)`
+  themselves. (Optionally `items_apply`.) The TS `apply` returns a
+  generic `T`; in practice `T` is always `Value` in this codebase.
+- `walk(val, before?, after?, maxdepth?, …recursion-state)`: public
+  `walk(val, before, after, maxdepth)` (each callback `Option<&mut dyn
+  FnMut(…)>` or a pair of overloads), private recursive `walk_impl(…,
+  key, parent, path, …)` for the state. The exposed `path` slice is
+  `&[String]` valid only for the callback (see §8).
+- `transform(data, spec, injdef?)`, `validate(…)`, `inject(val, store,
+  injdef?)`, `getpath(store, path, injdef?)`, `setpath(store, path, val,
+  injdef?)`, `merge(val, maxdepth?)`: take `injdef: Option<InjectDef>`
+  where `InjectDef` is a small `#[derive(Default)]` struct with the
+  publicly-meaningful `Partial<Injection>` fields (`extra`, `errs`,
+  `meta`, `modify`, `handler`, `base`, and the relative-path bits
+  `dpath`/`dparent` used by `$REF`). Internally fold it into a full
+  `Injection`.
+
+The C++ and Go ports already grappled with this (Go added
+`TransformModify`/`TransformCollect`/etc. variants because it can't even
+do optional `injdef`). A Rust port can do better than Go here — one
+`Option<InjectDef>` argument is enough.
+
+---
+
+## 8. `walk`, the path pool, and `merge`'s callbacks
+
+`walk` (canonical, lines ~915–975):
+
+- Recurses depth-first, calls `before` on descend and `after` on ascend,
+  each callback may *replace* the value (`setprop(out, ckey, walk(child,
+  …))`).
+- Uses a `string[][]` *pool* — one reusable array per depth — so the
+  `path` handed to callbacks isn't reallocated each step; the contract
+  is "the path is valid only during the callback; clone it if you need
+  to keep it" (the corpus's `match` machinery does `path.slice()`).
+
+Rust translation choices:
+
+1. **Drop the pool; use push/pop backtracking.** `walk_impl(val,
+   before, after, maxdepth, key, parent, path: &mut Vec<String>)`:
+   push the child key, recurse, pop. Hand callbacks `&path[..]`. Clean,
+   idiomatic, no aliasing. Slightly more allocation than the pool but a
+   `Vec<String>` reused via push/pop barely allocates after warm-up.
+   (There's a `walk-bench` test in `ts/test/`, so this is on the
+   project's radar — benchmark it, but correctness first.)
+2. **Callbacks as `&mut dyn FnMut(Option<&str>, &Value, &Value,
+   &[String]) -> Value`.** The recursive call reborrows them — fine.
+
+`merge` (canonical, lines ~982–1098) is the gnarliest piece:
+
+- For each input after the first, it `walk`s the override node with a
+  `before` that figures out the target slot in the output and a `after`
+  that writes it back, using two scratch arrays `cur` and `dst` captured
+  by *both* closures. Two `FnMut`s can't both hold `&mut` to the same
+  `Vec` in Rust.
+- **Option A (faithful):** wrap `cur`/`dst` as
+  `Rc<RefCell<Vec<Value>>>`; both closures hold `Rc` clones and
+  `borrow_mut()` in tight scopes. Keeps the code shape close to
+  canonical.
+- **Option B (idiomatic, recommended):** reimplement `merge` as a
+  direct recursive deep-merge — for two maps, merge key-by-key; for two
+  lists, merge by index; node-kind mismatch → override wins; scalars →
+  override wins; depth cap as in canonical. Document it in `NOTES.md` as
+  a deliberate divergence "for the same reason the TS port keeps it
+  walk-based: clarity in the host language." Several other ports already
+  treat `merge` as a hand-written recursion rather than literally
+  reusing `walk`. **This is the recommended path** — it removes the only
+  genuinely hostile borrow-checker fight in the library.
+
+Either way, watch `merge`'s in-place semantics: the canonical mutates
+`list[0]` (the first input) and returns it; `transform_MERGE` relies on
+that (it merges `[parent, …args, clone(parent)]` so the live `parent`
+node object is the one updated, keeping node-tree references intact).
+Reproduce that — `merge`'s result must *be* the (mutated) first node,
+same `Rc`, not a fresh one.
+
+---
+
+## 9. The `Injection` state machine
+
+`class Injection` (~20 fields: `mode`, `full`, `keyI`, `keys`, `key`,
+`val`, `parent`, `path`, `nodes`, `handler`, `errs`, `meta`, `dparent`,
+`dpath`, `base`, `modify`, `prior`, `extra`) plus methods `descend`,
+`child`, `setval`, `toString`.
+
+- Straightforward as a Rust struct passed `&mut`. The fields that hold
+  nodes (`parent`, `val`, `dparent`, `meta`, and the `Vec<Value>`
+  `nodes`) are cheap because nodes are `Rc`-backed.
+- `meta` is *shared by reference* across the whole injection subtree
+  (`child()` does `cinj.meta = this.meta`) and mutated (`this.meta.__d++`
+  in `descend`, `S_BEXACT` flag in validate/select). Modelling `meta` as
+  `Value::Map(Rc<RefCell<…>>)` makes this Just Work — `getprop`/`setprop`
+  on it behave like JS's by-reference object. This is a spot where the
+  `Rc<RefCell>` design pays for itself.
+- `errs` is likewise a shared list (`Value::List` or `Rc<RefCell<Vec<…>>>`)
+  — push-only. `child()` shares it; the root `inject` may take it from
+  `injdef.errs`.
+- `prior` is the parent injection. TS holds a reference; Rust can't hold
+  `&mut Injection` back-references safely, and `transform_REF` /
+  `injectChild` walk `inj.prior.prior` and *mutate* it (`inj.prior.keyI--`).
+  Options: (a) `prior: Option<Box<Injection>>` and accept that the
+  `keyI--` write lands on a *detached copy* — **wrong**, the canonical
+  needs that decrement visible to the in-flight parent loop in `inject`;
+  (b) restructure so `inject`'s child loop passes the relevant
+  `&mut`-able state down explicitly rather than via a back-pointer; (c)
+  `prior: Option<Rc<RefCell<Injection>>>` and make the whole injection
+  tree `Rc<RefCell>`-managed. **This needs a decision before
+  `transform_REF`/`$EACH`/`$PACK`/`$FORMAT`/`$APPLY` are implemented**
+  — it's the second-trickiest structural issue after `merge`. Likely
+  answer: (b) for the common case, with `child()` returning the new
+  injection by value and the parent loop re-reading `childinj.keyI` /
+  `childinj.keys` after each phase (which is *already* what `inject`
+  does — see the `nkI = childinj.keyI; nodekeys = childinj.keys`
+  re-reads after each of the three phases). The `inj.prior.keyI--` in
+  `transform_REF`/`injectChild` is the awkward exception; study those
+  three call sites carefully.
+- `child()` allocates a new `Injection` with `path`/`nodes` extended by
+  one — that's a `Vec` clone-plus-push each time (the TS uses
+  `flatten([this.path, key])`). Fine; could optimise later.
+
+---
+
+## 10. JSON & string formatting fidelity
+
+- **`jsonify`** must match `JSON.stringify(val, null, 2)`: 2-space
+  indent, `": "` after keys, `null` for `NaN`/`Infinity`, *drop*
+  `undefined`/function-valued object keys, *convert* `undefined`/
+  function array elements to `null`. Plus the `offset` flag that
+  left-pads every line but the first. `serde_json::to_string_pretty`
+  is close but won't make these JS-specific value substitutions and uses
+  its own spacing in a couple of spots — **write a small custom
+  serialiser** over `Value` rather than leaning on serde. The `catch →
+  "__JSONIFY_FAILED__"` branch becomes near-dead in Rust (nothing
+  throws; a cycle would stack-overflow, not be catchable).
+- **`stringify`** (human, *not* JSON): JSON-encodes with object keys
+  sorted, then deletes *every* `"` via `R_QUOTES = /"/g` (yes, including
+  quotes inside string values — a deliberate quirk), then truncates to
+  `maxlen` with a `"..."` tail. There's also an ANSI-colour "pretty"
+  branch (depth-coloured braces) — almost certainly not exercised by the
+  corpus but present; can stub-then-fill.
+- **`pathify`** renders a path (string | number | array) as a dotted
+  string, dropping non-`iskey` parts, stripping `.` from string parts,
+  flooring numeric parts, with `<root>` / `<unknown-path…>` fallbacks.
+  Straight port.
+- **`clone`** — see §6: recursive deep-copy, `Rc::clone` for funcs,
+  identity-preserve for sentinels.
+- **JS object integer-key reordering** is the one fidelity risk to flag:
+  `JSON.stringify({b:1, "2":2, a:3})` yields `{"2":2,"b":1,"a":3}`
+  because JS reorders integer-like keys to the front. An `IndexMap`
+  preserves *our* insertion order instead. This only leaks through
+  `jsonify` (and raw `JSON.stringify`-equivalents); `items`/`keysof`
+  sort and so don't expose it. Decide whether to emulate the reorder in
+  `jsonify` or accept the difference (probably accept; note it).
+- **`escurl`** = `encodeURIComponent`: percent-encode UTF-8 bytes,
+  uppercase hex, *not* escaping `A-Za-z0-9-_.!~*'()`. The
+  `percent-encoding` crate with a custom `AsciiSet`, or ~15 hand-rolled
+  lines.
+- **`escre`** escapes regex metacharacters char-by-char (`[.*+?^${}()|[\]\\]`
+  → `\` + char) — note it must be *regex* escaping (cf. Lua's port which
+  escapes Lua-pattern chars instead — not our problem, we have a real
+  regex engine).
+- **`$WHEN`** → ISO-8601 UTC string `"YYYY-MM-DDTHH:MM:SS.mmmZ"`. Pull
+  in `chrono` or `time`; the millisecond `.000Z` shape and calendar math
+  aren't worth hand-rolling. The corpus can't assert the exact value (it
+  changes) — it just needs *a* valid ISO string, possibly matched by a
+  regex in a `match` block.
+
+---
+
+## 11. Error handling
+
+- `transform` / `validate` `throw new Error(errs.join(" | "))` when no
+  `errs` collector was supplied; otherwise they collect into it.
+  Rust: return `Result<Value, StructError>` where `StructError {
+  message: String }` implements `Display`/`Error` (Go does `(any,
+  error)`; same idea). When `injdef.errs` is `Some`, return `Ok` and
+  fill the collector; when `None`, return `Err` if any errors.
+- `getpath`/`setpath`/`inject`/`merge`/all minor utils don't throw —
+  keep them infallible (return `Value`, not `Result`).
+- `jsonify`/`stringify`/`clone`'s internal `try/catch` → handled with
+  `match`/`Result` *inside* the function, producing the
+  `"__JSONIFY_FAILED__"` / `"__STRINGIFY_FAILED__"` strings; from the
+  caller's view these stay infallible.
+- The corpus runner matches expected errors by substring/regex against
+  `err.message` (see `ts/test/runner.ts` `handleError`/`matchval`), so
+  `StructError`'s `Display` must reproduce the canonical message text.
+
+---
+
+## 12. Names and constants
+
+- Rust convention is `snake_case`. **Recommendation:** rename to
+  `get_path`, `get_prop`, `is_node`, `is_map`, `is_list`, `is_key`,
+  `is_empty`, `is_func`, `keys_of`, `str_key`, `has_key`, `set_path`,
+  `set_prop`, `del_prop`, `type_name`, `get_def`, `get_elem`, `jsonify`,
+  `stringify`, `pathify`, `clone`, `escre`, `escurl`, `join`, etc.,
+  and ship a "TS name → Rust name" table in `README.md` (the repo
+  README already does this kind of cross-language casing note). Run
+  `clippy` clean. *Alternative:* keep the canonical lowercase names with
+  `#![allow(non_snake_case)]` for maximum line-by-line comparability —
+  weigh "real Rust crate" vs "diff-able against TS". Pick one and be
+  consistent.
+- Type bit-flags: `1 << 31` overflows `i32` (the C++ port hit this too),
+  so the bitfield type is **`u32`** (or `i64`). Constants: `T_ANY =
+  (1u32 << 31) - 1`, `T_NOVAL = 1 << 30`, … down to `T_NODE`. Rust has
+  no `t--`, so either hardcode the literals or generate them with a
+  `const fn` / small macro. `typename` uses `Math.clz32(t)` →
+  `t.leading_zeros() as usize` indexing into the `TYPENAME` table.
+  Mode flags `M_KEYPRE=1`, `M_KEYPOST=2`, `M_VAL=4` and the `MODENAME`
+  table — trivial.
+- `T_symbol`, `T_instance`, and the `bigint → T_any` branch have no
+  Rust analog in a JSON-shaped model. Keep the *constants* for parity
+  (`validate`'s `$INSTANCE`/`$FUNCTION` checkers and `merge`'s
+  `T_instance` guards reference them), but `typify` will essentially
+  never *return* `T_symbol`/`T_instance`. If the corpus turns out to
+  need a real "class instance", add a `Value::Instance(Rc<dyn Any>)`
+  escape-hatch variant later — don't build it speculatively.
+- `NONE` (TS's `undefined`) → `Value::Noval`. `S_*` string constants →
+  plain `&str` / `const` items. The `R_*` regexes → `once_cell::Lazy<Regex>`
+  (or `std::sync::LazyLock` on recent Rust).
+
+---
+
+## 13. Project layout
+
+Mirror the other language dirs (`go/`, `php/`, `zig/` are the closest
+templates):
+
+```
+rs/
+  Cargo.toml            # crate "voxgig-struct" (or "voxgig_struct"); deps below
+  src/
+    lib.rs              # public re-exports + the StructUtility-equivalent surface
+    value.rs            # Value enum, Sentinel, Func, PartialEq, Display helpers
+    struct_util.rs      # the port of StructUtility.ts (minor + major utils)
+                        #   — could stay one big file to track the canonical,
+                        #     or split: predicates / paths / merge / inject /
+                        #     transform / validate / select
+    injection.rs        # Injection struct + descend/child/setval
+    jsnum.rs            # JS-coercion helpers (+x, parseInt, Number, String(x))
+    jsonio.rs           # custom jsonify / stringify / clone-deep
+  tests/
+    corpus.rs           # loads ../build/test/test.json, drives every test set
+    runner/             # the runner.ts analog: marker handling (__NULL__ etc.),
+                        #   order-independent deep compare, name→fn dispatch,
+                        #   the mock client/utility/makeContext for SDK-flavoured
+                        #   tests (cf. go/testutil/{runner,sdk,direct}.go)
+    walk_bench.rs       # optional: the walk-bench analog (cargo bench / criterion)
+  Makefile              # inspect / build / test / clean / reset  (slots into ../Makefile)
+  README.md             # per-language guide + TS→Rust name table
+  NOTES.md              # undefined-vs-null, Rc<RefCell>, merge divergence, num model, …
+  REVIEW.md             # parity audit vs the TS canonical (written once it passes)
+```
+
+Also: add `rs/target/` (and `rs/Cargo.lock` policy — commit it, it's a
+bin-test crate effectively) handling to the top-level `.gitignore`; add
+`rs` to `LANGS` in the top-level [`Makefile`](../Makefile) and a
+`test-rs` target. Bump nothing else.
+
+**Dependencies (keep minimal):**
+
+- `indexmap` — insertion-ordered map. **Required.**
+- `regex` + `once_cell` (or stdlib `LazyLock`) — the `R_*` patterns and
+  dynamic regexes. **Required.**
+- `serde_json` — parse `build/test/test.json` (and maybe a serialise
+  bridge). **Test-only**, ideally; the library's own `jsonify` is
+  hand-rolled.
+- `chrono` *or* `time` — `$WHEN`. Small; or hand-roll if avoiding deps
+  matters.
+- `percent-encoding` — `escurl`. Optional (hand-rollable).
+- For `tests/`: a JSONic-aware parse isn't needed since `test.json` is
+  already plain JSON.
+- Edition 2021, MSRV pick something recent enough for `LazyLock` if used
+  (else `once_cell`).
+
+---
+
+## 14. Implementation roadmap (phased, each phase corpus-gated)
+
+The corpus splits naturally (`build/test/*.jsonic`): `minor`,
+`getpath`, `inject`, `merge`, `walk`, `transform`, `validate`, `select`,
+plus the top-level `primary` (SDK-flavoured) tests. Build bottom-up; run
+the relevant corpus slice at the end of each phase.
+
+1. **Foundation.** `Value`, `Sentinel`, `Func`, `PartialEq`/deep-equal,
+   `Rc<RefCell>` plumbing, `jsnum` helpers, the `R_*` regexes, type/mode
+   constants, `StructError`. No public functions yet.
+2. **Predicates & trivial accessors.** `typify`, `typename`, `isnode`,
+   `ismap`, `islist`, `iskey`, `isempty`, `isfunc`, `size`, `getdef`,
+   `strkey`. → first chunk of `minor.jsonic`.
+3. **Node ops.** `getprop`, `getelem`, `setprop`, `delprop`, `keysof`,
+   `haskey`, `items`, `flatten`, `filter`. → more of `minor.jsonic`.
+4. **Strings/JSON utils.** `escre`, `escurl`, `replace` (internal),
+   `join`, `pad`, `slice` (incl. number-input and `mutate` branches),
+   `pathify`, `jsonify`, `stringify`, `clone`, `jm`, `jt`. → rest of
+   `minor.jsonic`.
+5. **`walk`.** Push/pop path, callback signature. → `walk.jsonic`.
+6. **`merge`.** Direct recursive deep-merge (the §8 divergence),
+   in-place-on-first-node semantics. → `merge.jsonic`.
+7. **`getpath` / `setpath`.** Dotted + array paths, the empty-path =
+   store rule, the `injdef` relative-path bits (`$KEY`, `$GET:`,
+   `$REF:`, `$META:`, `$$` escape, the trailing-`.` ascend logic, the
+   `$=`/`$~` meta-path syntax), the `handler` hook. → `getpath.jsonic`.
+8. **`Injection` + `inject` core.** `descend`/`child`/`setval`, the
+   three-phase child loop (`M_KEYPRE`/`M_VAL`/`M_KEYPOST`), `_injectstr`
+   (full-match vs partial-match injection, `$BT`/`$DS` escapes inside
+   backticks, the `$NAME999` transform-name syntax), `_injecthandler`.
+   → `inject.jsonic`.
+9. **`transform` + the 11 commands.** `$DELETE`, `$COPY`, `$KEY`,
+   `$ANNO`, `$META`, `$MERGE`, then the structural ones `$EACH`,
+   `$PACK`, `$REF` (resolve the `prior`-pointer question from §9 here),
+   `$FORMAT` (+ `FORMATTER` table + `injectChild`), `$APPLY`.
+   `checkPlacement`, `injectorArgs`, `injectChild`. → `transform.jsonic`.
+10. **`validate` + the 15 checkers.** `validate_STRING`, `validate_TYPE`
+    (covers `$NUMBER`/`$INTEGER`/`$DECIMAL`/`$BOOLEAN`/`$NULL`/`$NIL`/
+    `$MAP`/`$LIST`/`$FUNCTION`/`$INSTANCE`), `$ANY`, `$CHILD`, `$ONE`,
+    `$EXACT`; `_validation` (the modify hook), `_validatehandler`;
+    `$OPEN` open-object handling; `_invalidTypeMsg` text. →
+    `validate.jsonic`.
+11. **`select` + operators.** `$AND`/`$OR`/`$NOT`/`$GT`/`$LT`/`$GTE`/
+    `$LTE`/`$LIKE`, the `$KEY`-injection trick, the `$OPEN` walk over the
+    query. → `select.jsonic`.
+12. **`StructUtility`-equivalent surface + the SDK/`primary` tests.**
+    The struct/module that bundles everything (TS's `StructUtility`
+    class), the mock client/utility/`makeContext` in `tests/runner/`
+    (port `go/testutil/sdk.go` + `direct.go`), the `primary.check`
+    tests. → full `test.json` green.
+13. **Docs & audit.** `README.md` (name table, install, quick-start),
+    `NOTES.md` (the divergences), `REVIEW.md` (parity matrix entry),
+    wire `rs` into the top-level `Makefile` and `REPORT.md`.
+14. **Polish.** `clippy`, `walk-bench` parity, doc-comments, decide the
+    `Cargo.lock` / `target/` ignore bits.
+
+---
+
+## 15. Risk register / open questions
+
+| # | Item | Why it matters | Leaning |
+|---|------|----------------|---------|
+| 1 | `Rc<RefCell>` borrow discipline | A naive transcription panics at runtime; this is the pervasive cost of the design. | Accept; enforce the "accessors return owned `Value`, never leak a guard" rule (§3); test hard. |
+| 2 | `merge` walk-callbacks → two `&mut`-capturing `FnMut`s | Borrow-checker-hostile as written. | Reimplement `merge` as direct recursion (§8 Option B); document the divergence. |
+| 3 | `Injection.prior` back-pointer + `inj.prior.keyI--` in `$REF`/`injectChild` | Can't safely hold `&mut` back-references; the decrement must be visible to the in-flight parent loop. | Pass mutable child-loop state down explicitly, re-reading `childinj.keyI`/`childinj.keys` (already the pattern in `inject`); treat `$REF`/`injectChild` as the studied exceptions (§9). Fallback: `Rc<RefCell<Injection>>` throughout. |
+| 4 | `Num(f64)` vs `enum N { Int, Float }` | Affects every numeric site; `f64` is more JS-faithful but less Rust-idiomatic; `Int/Float` needs normalisation rules. | `Num(f64)` + `is_integer`/`to_int32` helpers (§4); note the alternative. |
+| 5 | `snake_case` rename vs canonical names | "Real Rust crate" + clippy vs line-by-line comparability with TS. | `snake_case` + a TS→Rust name table in `README.md` (§12). |
+| 6 | `Rc<RefCell>` vs `Arc<Mutex>` (thread safety) | `Send`/`Sync` would touch every access site and add lock cost. | Single-threaded `Rc<RefCell>`; document "not thread-safe, like the JS canonical". Arc variant = out of scope. |
+| 7 | Number→string and large-magnitude exponent notation | Rust `{}` on `1e21` ≠ JS `"1e+21"`; `0.0000001` likewise. | Mostly used on small integer indices, so likely a non-issue; document as a known difference unless the corpus hits it. |
+| 8 | JS object integer-key reordering in `JSON.stringify` | `jsonify` could differ from canonical for maps with numeric-string keys. | Probably accept the `IndexMap`-order behaviour; note it; emulate only if the corpus demands. |
+| 9 | `T_symbol` / `T_instance` / `bigint` | No JSON-shaped Rust analog. | Keep constants for parity; `typify` won't return them; add a `Value::Instance` escape hatch only if the corpus needs it (§12). |
+| 10 | SDK/`primary` test machinery (mock client/utility/`makeContext`) | A non-trivial slice of the corpus needs it; it's ~3 files in `go/testutil/`. | Port it in phase 12; until then, run the per-function corpus slices and skip `primary`. |
+| 11 | Corpus runner deep-equality + marker semantics (`__NULL__`/`__UNDEF__`/`__EXISTS__`) and `/regex/` `match` entries | Getting the comparator wrong = false reds/greens. | Port `ts/test/runner.ts` carefully; map `deepStrictEqual` to an order-independent deep compare over `Value`; reuse the canonical's own `walk`/`getpath`/`stringify` in the `match` path exactly as the TS runner does. |
+| 12 | `$LIKE` / user-supplied `RegExp(term)` in `select` | Rust `regex` rejects some JS regex syntax. | Document the limitation; the corpus's `$LIKE` patterns are simple. |
+| 13 | Crate name & module split | `voxgig-struct` (crate) vs `voxgig_struct` (lib path); one big file vs modules. | Crate `voxgig-struct`, lib `voxgig_struct`; start with a near-monolithic `struct_util.rs` for comparability, split if it helps. |
+
+---
+
+## 16. Bottom line
+
+The hard 20% is all in one place: **shared mutable, reference-stable
+nodes** (`merge`, `inject`/`transform`/`validate`/`select`, the
+`Injection` state machine). `Rc<RefCell<…>>` + `IndexMap` is the right
+substrate — it's the direct analog of what C++ (`shared_ptr<List/Map>`),
+Go/PHP (`ListRef`), and Zig (`MapRef`/`ListRef`) already did — and the
+borrow-checker tax is paid up front by one discipline rule (§3) plus two
+or three studied exceptions (`merge`'s callbacks, `$REF`'s
+`prior.keyI--`). The other 80% — predicates, path ops, string/JSON
+utilities, the type bitfield, the transform/validate command tables — is
+a mechanical, well-understood transcription. The corpus
+(`build/test/test.json`) is the unambiguous oracle at every step, so the
+work is checkable phase by phase. Estimated shape: ~2,500–3,500 lines of
+library + ~800–1,200 lines of test harness, comparable to the Go port.

--- a/rs/README.md
+++ b/rs/README.md
@@ -1,7 +1,7 @@
 # Struct for Rust
 
 > Rust port of the canonical TypeScript implementation.
-> Status: **complete** — the full shared corpus passes (`cargo test` → 1122
+> Status: **complete** — the full shared corpus passes (`cargo test` → 1187
 > checks; `cargo clippy` clean): minor utilities, `walk`, `merge`, `getpath`,
 > `setpath`, `inject`, `transform` (all 11 commands), `validate` (all 15
 > checkers), `select` (all operators), and the `primary.check` SDK test. See

--- a/rs/README.md
+++ b/rs/README.md
@@ -1,0 +1,98 @@
+# Struct for Rust
+
+> Rust port of the canonical TypeScript implementation.
+> Status: **in progress** — foundation + minor utilities + `walk` / `merge` /
+> `getpath` / `setpath` are done and corpus-tested; `inject` / `transform` /
+> `validate` / `select` are staged. See [`NOTES.md`](./NOTES.md) and
+> [`PLAN.md`](./PLAN.md).
+
+For motivation, the language-neutral concepts, and the cross-language parity
+matrix, see the [top-level README](../README.md) and [`REPORT.md`](../REPORT.md).
+
+## Build & test
+
+Inside the monorepo:
+
+```bash
+cd rs
+cargo build
+cargo test          # runs the shared corpus (../build/test/test.json) against
+                    # the implemented subsets
+```
+
+Tested with a recent stable Rust (edition 2021). Crate: `voxgig-struct`;
+library path `voxgig_struct`.
+
+```rust
+use voxgig_struct::{Value, get_path};
+
+let store = Value::map_of([(
+    "db".to_string(),
+    Value::map_of([("host".to_string(), Value::str("localhost"))]),
+)]);
+let host = get_path(&store, &Value::str("db.host"), None);
+// host == Value::Str("localhost")
+```
+
+## In-memory data model
+
+```rust
+pub enum Value {
+    Noval,                                       // TS `undefined` — property absent
+    Null,                                        // JSON null — distinct from Noval
+    Bool(bool),
+    Num(f64),                                    // one numeric kind; integer-ness derived
+    Str(String),
+    List(Rc<RefCell<Vec<Value>>>),               // reference-stable, mutable in place
+    Map(Rc<RefCell<IndexMap<String, Value>>>),   // insertion-ordered, reference-stable
+    Func(Rc<dyn Fn(&Inj, &Value, &str, &Value) -> Value>),  // callable values in data
+    Sentinel(&'static Sentinel),                 // SKIP / DELETE — pointer identity
+}
+```
+
+`List` / `Map` are heap-allocated and reference-counted, so a mutation through
+one `Value` is visible to every holder — this is the canonical "lists are
+mutable and reference-stable" invariant. Not thread-safe (single-threaded data
+model, like the JS canonical).
+
+## Name mapping (TS canonical → Rust)
+
+The Rust API uses idiomatic `snake_case`. The repo already documents per-language
+casing (`getpath` in JS/Py/Lua/Rb/PHP, `GetPath` in Go/C#, `getPath` in Java); the
+Rust convention is `get_path`.
+
+| TS | Rust | TS | Rust |
+|---|---|---|---|
+| `typename` | `type_name` | `keysof` | `keys_of` |
+| `getdef` | `get_def` | `haskey` | `has_key` |
+| `isnode` / `ismap` / `islist` | `is_node` / `is_map` / `is_list` | `strkey` | `str_key` |
+| `iskey` / `isempty` / `isfunc` | `is_key` / `is_empty` / `is_func` | `escre` / `escurl` | `esc_re` / `esc_url` |
+| `getelem` / `getprop` | `get_elem` / `get_prop` | `getpath` / `setpath` | `get_path` / `set_path` |
+| `setprop` / `delprop` | `set_prop` / `del_prop` | `checkPlacement` | `check_placement` |
+| `getdef` | `get_def` | `injectorArgs` / `injectChild` | `injector_args` / `inject_child` |
+| `size` / `slice` / `pad` / `typify` | (same) | `clone` / `walk` / `merge` / `inject` | (same) |
+| `items` / `flatten` / `filter` / `join` | (same) | `transform` / `validate` / `select` | (same) |
+| `jsonify` / `stringify` / `pathify` | (same) | `jm` / `jt` | (same) |
+
+Type constants are SCREAMING_SNAKE: `T_ANY` … `T_NODE`, `M_KEYPRE` / `M_KEYPOST`
+/ `M_VAL`. Sentinels: `SKIP`, `DELETE`.
+
+## Optional parameters
+
+Rust has no optional/overloaded parameters, so:
+
+- `get_prop(node, key, alt)` / `get_elem(list, key, alt)` / `get_def(val, alt)`
+  take `alt: Value` (pass `Value::Noval` for the bare case). `get_elem_or_else`
+  takes a lazy alt closure.
+- `slice(val, start: Option<i64>, end: Option<i64>, mutate: bool)`.
+- `pad(s, padding: Option<i64>, padchar: Option<String>)`.
+- `walk(val, before: Option<&mut WalkClosure>, after: Option<&mut WalkClosure>, maxdepth: Option<i64>)`.
+- `merge(list, maxdepth: Option<i64>)`.
+- `get_path` / `set_path` / `transform` / `validate` / `inject` take
+  `injdef: Option<&InjectDef>` (a small `Default` struct of the publicly-set
+  `Partial<Injection>` fields).
+- `items(node)` returns a `Value::List` of `[key, value]` pairs; `items_vec`
+  returns `Vec<(String, Value)>`. Likewise `keys_of` / `keysof_vec`, `filter` /
+  `filter_vals`.
+
+See [`NOTES.md`](./NOTES.md) for the full set of decisions and what's still staged.

--- a/rs/README.md
+++ b/rs/README.md
@@ -56,6 +56,30 @@ one `Value` is visible to every holder — this is the canonical "lists are
 mutable and reference-stable" invariant. Not thread-safe (single-threaded data
 model, like the JS canonical).
 
+## Function values
+
+Callables embedded *in* the data (`Value::Func`) all use **one signature** —
+`Fn(&Inj, &Value /*val*/, &str /*ref*/, &Value /*store*/) -> Value` — created
+with `Value::func(closure)`. The TypeScript canonical is dynamically typed and
+uses a few different shapes for the same slots; the Rust port unifies them onto
+this signature, so the calling conventions differ slightly from TS:
+
+| Where | Rust call | Read for | TS canonical |
+|---|---|---|---|
+| Transform commands / validate checkers / select operators / the `handler` | `f(inj, val, ref, store)` | all four | `(inj, val, ref, store)` — same |
+| `$WHEN` / `$BT` / `$DS` / `$SPEC` thunks | `f(inj, val, ref, store)` (args ignored) | — | `()` — args ignored either way |
+| `$APPLY` (`['`$APPLY`', applyFn, child]`) | `f(inj, val, "", store)` | `val` = the resolved `child`; `store`; `inj` = the child injection | `apply(resolved, store, cinj)` — same data, different order |
+| `$FORMAT` user formatter (`['`$FORMAT`', fn, child]`) | applied to **each node** of the resolved `child`; `f(inj, val, "", store)` | `val` = the current node | `walk(resolved, formatter)` — TS's `formatter` also gets `(key, parent, path)`; the Rust form only sees `val` |
+| `get_elem(list, key, alt)` when `alt` is callable and the element is absent | `f(inj, val, "", store)` (a fresh throwaway injection, `Noval` val/store, empty ref) | — | `alt()` — args ignored either way |
+
+In short: a `Value::func` closure that reads its `val` argument (and `store` /
+`inj` if needed) behaves correctly everywhere. For `$FORMAT`, prefer the seven
+**built-in named formatters** — `identity`, `upper`, `lower`, `string`,
+`number`, `integer`, `concat` — passed as a string; a user function works but
+can't see the walk key / parent / path. (Note: callbacks passed as *parameters*
+— `walk`'s `before`/`after`, `filter`'s `check`, `InjectDef::modify` /
+`::handler` — are ordinary Rust closures and keep their full signatures.)
+
 ## Name mapping (TS canonical → Rust)
 
 The Rust API uses idiomatic `snake_case`. The repo already documents per-language

--- a/rs/README.md
+++ b/rs/README.md
@@ -1,12 +1,11 @@
 # Struct for Rust
 
 > Rust port of the canonical TypeScript implementation.
-> Status: **functionally complete** — all eight `struct/*` corpus files pass
-> (`cargo test` → 1120 checks): minor utilities, `walk`, `merge`, `getpath`,
+> Status: **complete** — the full shared corpus passes (`cargo test` → 1122
+> checks; `cargo clippy` clean): minor utilities, `walk`, `merge`, `getpath`,
 > `setpath`, `inject`, `transform` (all 11 commands), `validate` (all 15
-> checkers), `select` (all operators). The only thing not ported is the
-> top-level `primary` SDK-integration test (an example SDK built on `struct`,
-> not the library). See [`NOTES.md`](./NOTES.md) and [`PLAN.md`](./PLAN.md).
+> checkers), `select` (all operators), and the `primary.check` SDK test. See
+> [`NOTES.md`](./NOTES.md) and [`PLAN.md`](./PLAN.md).
 
 For motivation, the language-neutral concepts, and the cross-language parity
 matrix, see the [top-level README](../README.md) and [`REPORT.md`](../REPORT.md).

--- a/rs/README.md
+++ b/rs/README.md
@@ -1,10 +1,12 @@
 # Struct for Rust
 
 > Rust port of the canonical TypeScript implementation.
-> Status: **in progress** — foundation + minor utilities + `walk` / `merge` /
-> `getpath` / `setpath` are done and corpus-tested; `inject` / `transform` /
-> `validate` / `select` are staged. See [`NOTES.md`](./NOTES.md) and
-> [`PLAN.md`](./PLAN.md).
+> Status: **functionally complete** — all eight `struct/*` corpus files pass
+> (`cargo test` → 1120 checks): minor utilities, `walk`, `merge`, `getpath`,
+> `setpath`, `inject`, `transform` (all 11 commands), `validate` (all 15
+> checkers), `select` (all operators). The only thing not ported is the
+> top-level `primary` SDK-integration test (an example SDK built on `struct`,
+> not the library). See [`NOTES.md`](./NOTES.md) and [`PLAN.md`](./PLAN.md).
 
 For motivation, the language-neutral concepts, and the cross-language parity
 matrix, see the [top-level README](../README.md) and [`REPORT.md`](../REPORT.md).

--- a/rs/src/consts.rs
+++ b/rs/src/consts.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2025-2026 Voxgig Ltd. MIT LICENSE.
+// VERSION: @voxgig/struct 0.1.0
+//
+// String, type-bitflag, mode, and regex constants — port of the top of
+// StructUtility.ts. The bitfield type is `u32` (TS uses `(1<<31)-1` which
+// overflows a signed 32-bit int).
+
+#![allow(non_upper_case_globals)] // S_* string constants mirror the TS names
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// ---- mode flags (bitfield) for inject steps ---------------------------
+pub const M_KEYPRE: i64 = 1;
+pub const M_KEYPOST: i64 = 2;
+pub const M_VAL: i64 = 4;
+
+// ---- special strings --------------------------------------------------
+pub const S_BKEY: &str = "`$KEY`";
+pub const S_BANNO: &str = "`$ANNO`";
+pub const S_BEXACT: &str = "`$EXACT`";
+pub const S_BVAL: &str = "`$VAL`";
+pub const S_BOPEN: &str = "`$OPEN`";
+
+pub const S_DKEY: &str = "$KEY";
+pub const S_DTOP: &str = "$TOP";
+pub const S_DERRS: &str = "$ERRS";
+pub const S_DSPEC: &str = "$SPEC";
+
+// general
+pub const S_base: &str = "base";
+pub const S_key: &str = "key";
+pub const S_nil: &str = "nil";
+pub const S_null: &str = "null";
+pub const S_string: &str = "string";
+pub const S_object: &str = "object";
+pub const S_list: &str = "list";
+pub const S_map: &str = "map";
+
+// chars
+pub const S_BT: &str = "`";
+pub const S_CN: &str = ":";
+pub const S_DS: &str = "$";
+pub const S_DT: &str = ".";
+pub const S_FS: &str = "/";
+pub const S_KEY: &str = "KEY";
+pub const S_MT: &str = "";
+pub const S_SP: &str = " ";
+pub const S_CM: &str = ",";
+pub const S_VIZ: &str = ": ";
+
+// ---- type bit codes (u32) ---------------------------------------------
+// let t = 31; T_any = (1<<t--)-1; ... (see StructUtility.ts).
+pub const T_ANY: u32 = (1u32 << 31) - 1; // 0x7FFF_FFFF
+pub const T_NOVAL: u32 = 1 << 30; // property absent, undefined. NOT a scalar.
+pub const T_BOOLEAN: u32 = 1 << 29;
+pub const T_DECIMAL: u32 = 1 << 28;
+pub const T_INTEGER: u32 = 1 << 27;
+pub const T_NUMBER: u32 = 1 << 26;
+pub const T_STRING: u32 = 1 << 25;
+pub const T_FUNCTION: u32 = 1 << 24;
+pub const T_SYMBOL: u32 = 1 << 23;
+pub const T_NULL: u32 = 1 << 22; // the actual JSON null value.
+// t -= 7  => t = 14
+pub const T_LIST: u32 = 1 << 14;
+pub const T_MAP: u32 = 1 << 13;
+pub const T_INSTANCE: u32 = 1 << 12;
+// t -= 4  => t = 7
+pub const T_SCALAR: u32 = 1 << 7;
+pub const T_NODE: u32 = 1 << 6;
+
+// TYPENAME indexed by Math.clz32(t). 26 entries (0..=25).
+pub const TYPENAME: [&str; 26] = [
+    "any",      // 0
+    "nil",      // 1   clz32(T_noval=1<<30)
+    "boolean",  // 2   clz32(1<<29)
+    "decimal",  // 3   clz32(1<<28)
+    "integer",  // 4   clz32(1<<27)
+    "number",   // 5   clz32(1<<26)
+    "string",   // 6   clz32(1<<25)
+    "function", // 7   clz32(1<<24)
+    "symbol",   // 8   clz32(1<<23)
+    "null",     // 9   clz32(1<<22)
+    "", "", "", "", "", "", "", // 10..=16
+    "list",     // 17  clz32(1<<14)
+    "map",      // 18  clz32(1<<13)
+    "instance", // 19  clz32(1<<12)
+    "", "", "", "", // 20..=23
+    "scalar",   // 24  clz32(1<<7)
+    "node",     // 25  clz32(1<<6)
+];
+
+pub const MAXDEPTH: i64 = 32;
+
+// ---- regexes ----------------------------------------------------------
+pub static R_INTEGER_KEY: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[-0-9]+$").unwrap());
+pub static R_ESCAPE_REGEXP: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[.*+?^${}()|\[\]\\]").unwrap());
+pub static R_QUOTES: Lazy<Regex> = Lazy::new(|| Regex::new(r#"""#).unwrap());
+pub static R_DOT: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.").unwrap());
+pub static R_CLONE_REF: Lazy<Regex> = Lazy::new(|| Regex::new(r"^`\$REF:([0-9]+)`$").unwrap());
+pub static R_META_PATH: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([^$]+)\$([=~])(.+)$").unwrap());
+pub static R_TRANSFORM_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"`\$([A-Z]+)`").unwrap());
+pub static R_INJECTION_FULL: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^`(\$[A-Z]+|[^`]*)[0-9]*`$").unwrap());
+pub static R_INJECTION_PARTIAL: Lazy<Regex> = Lazy::new(|| Regex::new(r"`([^`]+)`").unwrap());
+
+pub fn mode_name(mode: i64) -> &'static str {
+    match mode {
+        M_VAL => "val",
+        M_KEYPRE => "key:pre",
+        M_KEYPOST => "key:post",
+        _ => "",
+    }
+}
+
+pub fn placement_name(mode: i64) -> &'static str {
+    match mode {
+        M_VAL => "value",
+        M_KEYPRE | M_KEYPOST => "key",
+        _ => "",
+    }
+}

--- a/rs/src/lib.rs
+++ b/rs/src/lib.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2025-2026 Voxgig Ltd. MIT LICENSE.
+// VERSION: @voxgig/struct 0.1.0
+//
+// Voxgig Struct — Rust port of the canonical TypeScript implementation
+// (ts/src/StructUtility.ts). See rs/PLAN.md for the porting plan and the
+// list of deliberate divergences (idiomatic snake_case names, Rc<RefCell>
+// reference-stable nodes, merge as a direct recursion, ...).
+
+#![allow(clippy::too_many_arguments)]
+
+pub mod consts;
+pub mod value;
+
+mod major;
+mod mini;
+
+pub use value::{Sentinel, Value, DELETE, SKIP};
+
+pub use consts::{
+    M_KEYPOST, M_KEYPRE, M_VAL, T_ANY, T_BOOLEAN, T_DECIMAL, T_FUNCTION, T_INSTANCE, T_INTEGER,
+    T_LIST, T_MAP, T_NODE, T_NOVAL, T_NULL, T_NUMBER, T_SCALAR, T_STRING, T_SYMBOL,
+};
+
+pub use mini::{
+    clone, del_prop, esc_re, esc_url, filter, filter_vals, flatten, get_def, get_elem,
+    get_elem_or_else, get_prop, has_key, is_empty, is_func, is_key, is_list, is_map, is_node,
+    items, jm, jt, jsonify, join, join_vals, keys_of, keysof_vec, pad, pathify, set_prop, size,
+    slice, str_key, stringify, type_name, typify,
+};
+
+pub use major::{
+    check_placement, get_path, get_path_inj, inject, inject_child, injector_args, merge, select,
+    set_path, transform, validate, walk, Inj, InjectDef, Injection, Modify, NativeFn, WalkClosure,
+};
+
+pub use mini::JsonFlags;
+
+/// Error raised by `transform` / `validate` when no error collector was
+/// supplied (mirrors the TS `throw new Error(errs.join(' | '))`).
+#[derive(Debug, Clone)]
+pub struct StructError {
+    pub message: String,
+}
+
+impl std::fmt::Display for StructError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StructError {}
+
+/// Bundle of all functions, mirroring the TS `StructUtility` class. Useful
+/// for the test harness (which looks subjects up by name).
+pub struct StructUtility;
+
+impl StructUtility {
+    pub fn new() -> Self {
+        StructUtility
+    }
+}
+
+impl Default for StructUtility {
+    fn default() -> Self {
+        StructUtility
+    }
+}

--- a/rs/src/major.rs
+++ b/rs/src/major.rs
@@ -79,8 +79,8 @@ fn walk_impl(
             path.push(ckey.clone());
             let res = walk_impl(
                 child,
-                before.as_mut().map(|f| &mut **f),
-                after.as_mut().map(|f| &mut **f),
+                before.as_deref_mut(),
+                after.as_deref_mut(),
                 maxdepth,
                 &Value::str(ckey.clone()),
                 &out,
@@ -1677,7 +1677,7 @@ pub fn transform(
     if errlen > 0 && !collect {
         let msgs: Vec<String> = errs
             .as_list()
-            .map(|l| l.borrow().iter().map(|e| js_string(e)).collect())
+            .map(|l| l.borrow().iter().map(js_string).collect())
             .unwrap_or_default();
         return Err(StructError {
             message: msgs.join(" | "),

--- a/rs/src/major.rs
+++ b/rs/src/major.rs
@@ -2193,8 +2193,260 @@ pub fn validate(
     Ok(out)
 }
 
-pub fn select(_children: &Value, _query: &Value) -> Value {
-    unimplemented!("select: not yet ported — see rs/PLAN.md §11 and rs/NOTES.md")
+// ---- select ----------------------------------------------------------
+
+fn js_lt(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Str(x), Value::Str(y)) => x < y,
+        _ => {
+            let (x, y) = (js_to_number(a), js_to_number(b));
+            x < y // NaN -> false, matches JS
+        }
+    }
+}
+fn js_gt(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Str(x), Value::Str(y)) => x > y,
+        _ => {
+            let (x, y) = (js_to_number(a), js_to_number(b));
+            x > y
+        }
+    }
+}
+
+fn select_subvalidate(point: &Value, term: &Value, store: &Value, meta: &Value) -> bool {
+    let vstore = match merge(&Value::list(vec![Value::empty_map(), store.clone()]), Some(1)) {
+        v @ Value::Map(_) => v,
+        _ => Value::empty_map(),
+    };
+    set_prop(vstore.clone(), &Value::str(S_DTOP), point.clone());
+    let terrs = Value::empty_list();
+    let vd = InjectDef {
+        extra: Some(vstore),
+        errs: Some(terrs.clone()),
+        meta: Some(meta.clone()),
+        ..Default::default()
+    };
+    let _ = validate(point, term, Some(&vd));
+    terrs.as_list().map(|l| l.borrow().is_empty()).unwrap_or(true)
+}
+
+fn select_and(inj: &Inj, _v: &Value, _r: &str, store: &Value) -> Value {
+    if inj.borrow().mode != M_KEYPRE {
+        return Value::Noval;
+    }
+    let (key, parent, path, nodes, meta) = {
+        let b = inj.borrow();
+        (b.key.clone(), b.parent.clone(), b.path.clone(), b.nodes.clone(), b.meta.clone())
+    };
+    let terms: Vec<Value> = get_prop(&parent, &Value::str(key), Value::Noval)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    let ppath = slice_str_vec(&path, Some(-1), None);
+    let point = get_path_inj(store, &path_value(&ppath), None);
+    for term in &terms {
+        if !select_subvalidate(&point, term, store, &meta) {
+            errs_push(
+                inj,
+                format!(
+                    "AND:{}{}{} fail:{}",
+                    pathify(&path_value(&ppath), None, None),
+                    S_VIZ,
+                    stringify(&point, None, false),
+                    stringify(&Value::list(terms.clone()), None, false)
+                ),
+            );
+        }
+    }
+    let gkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let nlen = nodes.len();
+    if nlen >= 2 {
+        set_prop(nodes[nlen - 2].clone(), &Value::str(gkey), point);
+    }
+    Value::Noval
+}
+
+fn select_or(inj: &Inj, _v: &Value, _r: &str, store: &Value) -> Value {
+    if inj.borrow().mode != M_KEYPRE {
+        return Value::Noval;
+    }
+    let (key, parent, path, nodes, meta) = {
+        let b = inj.borrow();
+        (b.key.clone(), b.parent.clone(), b.path.clone(), b.nodes.clone(), b.meta.clone())
+    };
+    let terms: Vec<Value> = get_prop(&parent, &Value::str(key), Value::Noval)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    let ppath = slice_str_vec(&path, Some(-1), None);
+    let point = get_path_inj(store, &path_value(&ppath), None);
+    for term in &terms {
+        if select_subvalidate(&point, term, store, &meta) {
+            let gkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+            let nlen = nodes.len();
+            if nlen >= 2 {
+                set_prop(nodes[nlen - 2].clone(), &Value::str(gkey), point);
+            }
+            return Value::Noval;
+        }
+    }
+    errs_push(
+        inj,
+        format!(
+            "OR:{}{}{} fail:{}",
+            pathify(&path_value(&ppath), None, None),
+            S_VIZ,
+            stringify(&point, None, false),
+            stringify(&Value::list(terms.clone()), None, false)
+        ),
+    );
+    Value::Noval
+}
+
+fn select_not(inj: &Inj, _v: &Value, _r: &str, store: &Value) -> Value {
+    if inj.borrow().mode != M_KEYPRE {
+        return Value::Noval;
+    }
+    let (key, parent, path, nodes, meta) = {
+        let b = inj.borrow();
+        (b.key.clone(), b.parent.clone(), b.path.clone(), b.nodes.clone(), b.meta.clone())
+    };
+    let term = get_prop(&parent, &Value::str(key), Value::Noval);
+    let ppath = slice_str_vec(&path, Some(-1), None);
+    let point = get_path_inj(store, &path_value(&ppath), None);
+    if select_subvalidate(&point, &term, store, &meta) {
+        errs_push(
+            inj,
+            format!(
+                "NOT:{}{}{} fail:{}",
+                pathify(&path_value(&ppath), None, None),
+                S_VIZ,
+                stringify(&point, None, false),
+                stringify(&term, None, false)
+            ),
+        );
+    }
+    let gkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let nlen = nodes.len();
+    if nlen >= 2 {
+        set_prop(nodes[nlen - 2].clone(), &Value::str(gkey), point);
+    }
+    Value::Noval
+}
+
+fn select_cmp(inj: &Inj, _v: &Value, r: &str, store: &Value) -> Value {
+    if inj.borrow().mode != M_KEYPRE {
+        return Value::Noval;
+    }
+    let (key, parent, path, nodes) = {
+        let b = inj.borrow();
+        (b.key.clone(), b.parent.clone(), b.path.clone(), b.nodes.clone())
+    };
+    let term = get_prop(&parent, &Value::str(key), Value::Noval);
+    let gkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let ppath = slice_str_vec(&path, Some(-1), None);
+    let point = get_path_inj(store, &path_value(&ppath), None);
+
+    let pass = match r {
+        "$GT" => js_gt(&point, &term),
+        "$LT" => js_lt(&point, &term),
+        "$GTE" => js_gt(&point, &term) || point == term,
+        "$LTE" => js_lt(&point, &term) || point == term,
+        "$LIKE" => {
+            let pat = term.as_str().unwrap_or("").to_string();
+            regex::Regex::new(&pat)
+                .map(|re| re.is_match(&stringify(&point, None, false)))
+                .unwrap_or(false)
+        }
+        _ => false,
+    };
+
+    if pass {
+        let nlen = nodes.len();
+        if nlen >= 2 {
+            set_prop(nodes[nlen - 2].clone(), &Value::str(gkey), point);
+        }
+    } else {
+        errs_push(
+            inj,
+            format!(
+                "CMP: {}{}{} fail:{} {}",
+                pathify(&path_value(&ppath), None, None),
+                S_VIZ,
+                stringify(&point, None, false),
+                r,
+                stringify(&term, None, false)
+            ),
+        );
+    }
+    Value::Noval
+}
+
+pub fn select(children: &Value, query: &Value) -> Value {
+    if !is_node(children) {
+        return Value::empty_list();
+    }
+
+    let child_list: Vec<Value> = match children {
+        Value::Map(_) => items_vec(children)
+            .into_iter()
+            .map(|(k, v)| {
+                set_prop(v.clone(), &Value::str(S_DKEY), Value::str(k));
+                v
+            })
+            .collect(),
+        Value::List(_) => items_vec(children)
+            .into_iter()
+            .map(|(k, v)| {
+                set_prop(
+                    v.clone(),
+                    &Value::str(S_DKEY),
+                    Value::Num(k.parse::<f64>().unwrap_or(f64::NAN)),
+                );
+                v
+            })
+            .collect(),
+        _ => return Value::empty_list(),
+    };
+
+    let extra = Value::map_of([
+        ("$AND".to_string(), Value::func(select_and)),
+        ("$OR".to_string(), Value::func(select_or)),
+        ("$NOT".to_string(), Value::func(select_not)),
+        ("$GT".to_string(), Value::func(select_cmp)),
+        ("$LT".to_string(), Value::func(select_cmp)),
+        ("$GTE".to_string(), Value::func(select_cmp)),
+        ("$LTE".to_string(), Value::func(select_cmp)),
+        ("$LIKE".to_string(), Value::func(select_cmp)),
+    ]);
+    let meta = Value::map_of([(S_BEXACT.to_string(), Value::Bool(true))]);
+
+    let q = clone(query);
+    let mut open = |_k: &Value, v: &Value, _p: &Value, _t: &[String]| -> Value {
+        if is_map(v) {
+            let cur = get_prop(v, &Value::str(S_BOPEN), Value::Bool(true));
+            set_prop(v.clone(), &Value::str(S_BOPEN), cur);
+        }
+        v.clone()
+    };
+    walk(q.clone(), Some(&mut open), None, None);
+
+    let mut results: Vec<Value> = Vec::new();
+    for child in &child_list {
+        let errs = Value::empty_list();
+        let vd = InjectDef {
+            errs: Some(errs.clone()),
+            meta: Some(meta.clone()),
+            extra: Some(extra.clone()),
+            ..Default::default()
+        };
+        let _ = validate(child, &clone(&q), Some(&vd));
+        if errs.as_list().map(|l| l.borrow().is_empty()).unwrap_or(true) {
+            results.push(child.clone());
+        }
+    }
+    Value::list(results)
 }
 
 // keep `Injection::has_handler` referenced (used once staging is complete)

--- a/rs/src/major.rs
+++ b/rs/src/major.rs
@@ -1,0 +1,595 @@
+// Copyright (c) 2025-2026 Voxgig Ltd. MIT LICENSE.
+// VERSION: @voxgig/struct 0.1.0
+//
+// Major utilities — walk, merge, getpath, setpath, and (staged) the
+// inject / transform / validate / select machinery. See rs/PLAN.md §8-§11.
+//
+// `merge` is implemented walk-based to stay close to the canonical; the
+// `cur`/`dst` scratch vectors are shared between the before/after closures
+// via `Rc<RefCell<…>>` (Rust can't have two FnMut closures both holding a
+// `&mut` to the same Vec).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::consts::*;
+use crate::mini::*;
+use crate::value::{js_string, Value};
+use crate::StructError;
+
+// ---------------------------------------------------------------------
+// callback / function types
+// ---------------------------------------------------------------------
+
+/// `WalkApply` — `(key, val, parent, path) -> any`. `key` is `Noval` at the
+/// root and a `Str` for every descendant (matches the canonical, where
+/// `items` always yields string keys).
+pub type WalkClosure<'a> = dyn FnMut(&Value, &Value, &Value, &[String]) -> Value + 'a;
+
+/// `Injector` — `(inj, val, ref, store) -> any`.
+pub type NativeFn = crate::value::NativeFn;
+
+/// `Modify` — `(val, key, parent, inj, store)`.
+pub type Modify = crate::value::ModifyFn;
+
+pub type Inj = Rc<RefCell<Injection>>;
+pub type SVec = Rc<RefCell<Vec<String>>>;
+
+// ---------------------------------------------------------------------
+// walk
+// ---------------------------------------------------------------------
+
+pub fn walk(
+    val: Value,
+    before: Option<&mut WalkClosure>,
+    after: Option<&mut WalkClosure>,
+    maxdepth: Option<i64>,
+) -> Value {
+    let mut path: Vec<String> = Vec::new();
+    walk_impl(val, before, after, maxdepth, &Value::Noval, &Value::Noval, &mut path)
+}
+
+fn walk_impl(
+    val: Value,
+    mut before: Option<&mut WalkClosure>,
+    mut after: Option<&mut WalkClosure>,
+    maxdepth: Option<i64>,
+    key: &Value,
+    parent: &Value,
+    path: &mut Vec<String>,
+) -> Value {
+    let depth = path.len() as i64;
+
+    let out = match before {
+        Some(ref mut f) => f(key, &val, parent, path),
+        None => val,
+    };
+
+    let md = match maxdepth {
+        Some(m) if m >= 0 => m,
+        _ => MAXDEPTH,
+    };
+    if md == 0 || (md > 0 && md <= depth) {
+        return out;
+    }
+
+    if is_node(&out) {
+        let entries = items_vec(&out);
+        for (ckey, child) in entries {
+            path.push(ckey.clone());
+            let res = walk_impl(
+                child,
+                before.as_mut().map(|f| &mut **f),
+                after.as_mut().map(|f| &mut **f),
+                maxdepth,
+                &Value::str(ckey.clone()),
+                &out,
+                path,
+            );
+            path.pop();
+            set_prop(out.clone(), &Value::str(ckey), res);
+        }
+    }
+
+    match after {
+        Some(ref mut f) => f(key, &out, parent, path),
+        None => out,
+    }
+}
+
+// ---------------------------------------------------------------------
+// merge
+// ---------------------------------------------------------------------
+
+const T_INSTANCE_I: i64 = T_INSTANCE as i64;
+
+pub fn merge(val: &Value, maxdepth: Option<i64>) -> Value {
+    let md = match slice(
+        Value::Num(maxdepth.unwrap_or(MAXDEPTH) as f64),
+        Some(0),
+        None,
+        false,
+    ) {
+        Value::Num(n) => n as i64,
+        _ => MAXDEPTH,
+    };
+
+    let list: Vec<Value> = match val {
+        Value::List(l) => l.borrow().clone(),
+        other => return other.clone(),
+    };
+
+    if list.is_empty() {
+        return Value::Noval;
+    }
+    if list.len() == 1 {
+        return list[0].clone();
+    }
+
+    let mut out = match &list[0] {
+        Value::Noval => Value::empty_map(),
+        other => other.clone(),
+    };
+
+    for obj in list.iter().skip(1) {
+        let obj = obj.clone();
+        if !is_node(&obj) {
+            out = obj;
+            continue;
+        }
+
+        let cur: Rc<RefCell<Vec<Value>>> = Rc::new(RefCell::new(vec![out.clone()]));
+        let dst: Rc<RefCell<Vec<Value>>> = Rc::new(RefCell::new(vec![out.clone()]));
+
+        let cur_b = cur.clone();
+        let dst_b = dst.clone();
+        let mut before = move |key: &Value, v: &Value, _parent: &Value, path: &[String]| -> Value {
+            let pi = path.len() as i64;
+            let mut ret = v.clone();
+
+            if md <= pi {
+                let target = cur_b
+                    .borrow()
+                    .get((pi - 1) as usize)
+                    .cloned()
+                    .unwrap_or(Value::Noval);
+                set_prop(target, key, v.clone());
+            } else if !is_node(v) {
+                let mut cb = cur_b.borrow_mut();
+                grow(&mut cb, pi as usize);
+                cb[pi as usize] = v.clone();
+            } else {
+                let tval = {
+                    let d = if pi > 0 {
+                        let prev = dst_b
+                            .borrow()
+                            .get((pi - 1) as usize)
+                            .cloned()
+                            .unwrap_or(Value::Noval);
+                        get_prop(&prev, key, Value::Noval)
+                    } else {
+                        dst_b.borrow().get(pi as usize).cloned().unwrap_or(Value::Noval)
+                    };
+                    let mut db = dst_b.borrow_mut();
+                    grow(&mut db, pi as usize);
+                    db[pi as usize] = d.clone();
+                    d
+                };
+                let mut cb = cur_b.borrow_mut();
+                grow(&mut cb, pi as usize);
+                if tval.is_noval() && (typify(v) & T_INSTANCE_I) == 0 {
+                    cb[pi as usize] = if is_list(v) {
+                        Value::empty_list()
+                    } else {
+                        Value::empty_map()
+                    };
+                } else if typify(v) == typify(&tval) {
+                    cb[pi as usize] = tval;
+                } else {
+                    cb[pi as usize] = v.clone();
+                    ret = Value::Noval;
+                }
+            }
+            ret
+        };
+
+        let cur_a = cur.clone();
+        let mut after = move |key: &Value, _v: &Value, _parent: &Value, path: &[String]| -> Value {
+            let ci = path.len() as i64;
+            let (target, value) = {
+                let cb = cur_a.borrow();
+                (
+                    cb.get((ci - 1) as usize).cloned().unwrap_or(Value::Noval),
+                    cb.get(ci as usize).cloned().unwrap_or(Value::Noval),
+                )
+            };
+            set_prop(target, key, value.clone());
+            value
+        };
+
+        out = walk(obj, Some(&mut before), Some(&mut after), maxdepth);
+    }
+
+    if md == 0 {
+        let last = get_elem(&Value::list(list.clone()), &Value::Num(-1.0), Value::Noval);
+        out = match &last {
+            Value::List(_) => Value::empty_list(),
+            Value::Map(_) => Value::empty_map(),
+            other => other.clone(),
+        };
+    }
+
+    out
+}
+
+fn grow(v: &mut Vec<Value>, idx: usize) {
+    while v.len() <= idx {
+        v.push(Value::Noval);
+    }
+}
+
+// ---------------------------------------------------------------------
+// Injection state
+// ---------------------------------------------------------------------
+
+pub struct Injection {
+    pub mode: i64,
+    pub full: bool,
+    pub key_i: i64,
+    pub keys: SVec,
+    pub key: String,
+    pub val: Value,
+    pub parent: Value,
+    pub path: Vec<String>,
+    pub nodes: Vec<Value>,
+    pub handler: NativeFn,
+    pub errs: Value, // Value::List
+    pub meta: Value, // Value::Map
+    pub dparent: Value,
+    pub dpath: Vec<String>,
+    pub base: Option<String>,
+    pub modify: Option<Modify>,
+    pub extra: Option<Value>,
+    pub prior: Option<Inj>,
+}
+
+/// Public `injdef` argument — the subset of `Partial<Injection>` callers set.
+#[derive(Default, Clone)]
+pub struct InjectDef {
+    pub base: Option<String>,
+    pub errs: Option<Value>,
+    pub meta: Option<Value>,
+    pub modify: Option<Modify>,
+    pub handler: Option<NativeFn>,
+    pub extra: Option<Value>,
+    pub dparent: Option<Value>,
+    pub dpath: Option<Vec<String>>,
+    pub key: Option<Value>,
+}
+
+impl Injection {
+    /// Build a (mostly-empty) injection carrying just the fields the public
+    /// `getpath` / `setpath` read from an `injdef`.
+    pub fn from_def(def: Option<&InjectDef>) -> Inj {
+        let inj = Injection {
+            mode: M_VAL,
+            full: false,
+            key_i: 0,
+            keys: Rc::new(RefCell::new(vec![S_DTOP.to_string()])),
+            key: S_DTOP.to_string(),
+            val: Value::Noval,
+            parent: Value::Noval,
+            path: vec![S_DTOP.to_string()],
+            nodes: vec![Value::Noval],
+            handler: inject_handler_fn(),
+            errs: Value::empty_list(),
+            meta: Value::empty_map(),
+            dparent: Value::Noval,
+            dpath: vec![S_DTOP.to_string()],
+            base: None,
+            modify: None,
+            extra: None,
+            prior: None,
+        };
+        let inj = Rc::new(RefCell::new(inj));
+        if let Some(d) = def {
+            let mut b = inj.borrow_mut();
+            if let Some(x) = &d.base {
+                b.base = Some(x.clone());
+            }
+            if let Some(x) = &d.errs {
+                b.errs = x.clone();
+            }
+            if let Some(x) = &d.meta {
+                b.meta = x.clone();
+            }
+            if let Some(x) = &d.modify {
+                b.modify = Some(x.clone());
+            }
+            if let Some(x) = &d.handler {
+                b.handler = x.clone();
+            }
+            if let Some(x) = &d.extra {
+                b.extra = Some(x.clone());
+            }
+            if let Some(x) = &d.dparent {
+                b.dparent = x.clone();
+            }
+            if let Some(x) = &d.dpath {
+                b.dpath = x.clone();
+            }
+            if let Some(x) = &d.key {
+                b.key = str_key(x.clone());
+            }
+        }
+        inj
+    }
+
+    fn has_handler(def: Option<&InjectDef>) -> bool {
+        def.map(|d| d.handler.is_some()).unwrap_or(false)
+    }
+}
+
+// ---------------------------------------------------------------------
+// getpath
+// ---------------------------------------------------------------------
+
+pub fn get_path(store: &Value, path: &Value, injdef: Option<&InjectDef>) -> Value {
+    let inj: Option<Inj> = injdef.map(|_| Injection::from_def(injdef));
+    get_path_inj(store, path, inj.as_ref())
+}
+
+/// Internal `getpath` working against a full `Inj` (used by the inject
+/// machinery and by the public `get_path` wrapper).
+pub fn get_path_inj(store: &Value, path: &Value, injdef: Option<&Inj>) -> Value {
+    let mut parts: Vec<String> = match path {
+        Value::List(l) => l
+            .borrow()
+            .iter()
+            .map(|x| match x {
+                Value::Str(s) => s.clone(),
+                other => js_string(other),
+            })
+            .collect(),
+        Value::Str(s) => s.split('.').map(|p| p.to_string()).collect(),
+        Value::Num(n) => vec![str_key(Value::Num(*n))],
+        _ => return Value::Noval,
+    };
+
+    let base = injdef.and_then(|i| i.borrow().base.clone());
+    let src = match &base {
+        Some(b) => get_prop(store, &Value::str(b.clone()), store.clone()),
+        None => store.clone(),
+    };
+    let numparts = parts.len();
+    let dparent = injdef.map(|i| i.borrow().dparent.clone()).unwrap_or(Value::Noval);
+
+    let mut val = store.clone();
+
+    let path_nullish = matches!(path, Value::Noval | Value::Null);
+    if path_nullish
+        || matches!(store, Value::Noval | Value::Null)
+        || (numparts == 1 && parts[0].is_empty())
+    {
+        val = src.clone();
+    } else if numparts > 0 {
+        if numparts == 1 {
+            val = get_prop(store, &Value::str(parts[0].clone()), Value::Noval);
+        }
+
+        if !is_func(&val) {
+            val = src.clone();
+
+            // meta path prefix:  "name$=..."  /  "name$~..."
+            if let Some(inj) = injdef {
+                let meta = inj.borrow().meta.clone();
+                let first = parts[0].clone();
+                if let Some(caps) = R_META_PATH.captures(&first) {
+                    if !meta.is_noval() {
+                        val = get_prop(&meta, &Value::str(caps[1].to_string()), Value::Noval);
+                        parts[0] = caps[3].to_string();
+                    }
+                }
+            }
+
+            let dpath: Vec<String> = injdef.map(|i| i.borrow().dpath.clone()).unwrap_or_default();
+
+            let mut p_i = 0usize;
+            while !val.is_noval() && p_i < numparts {
+                let mut part = parts[p_i].clone();
+
+                if let Some(inj) = injdef {
+                    if part == S_DKEY {
+                        part = inj.borrow().key.clone();
+                    } else if let Some(rest) = part.strip_prefix("$GET:") {
+                        part = js_string(&get_path_inj(&src, &Value::str(drop_last(rest)), None));
+                    } else if let Some(rest) = part.strip_prefix("$REF:") {
+                        let spec = get_prop(store, &Value::str(S_DSPEC), Value::Noval);
+                        part = js_string(&get_path_inj(&spec, &Value::str(drop_last(rest)), None));
+                    } else if let Some(rest) = part.strip_prefix("$META:") {
+                        let meta = inj.borrow().meta.clone();
+                        part = js_string(&get_path_inj(&meta, &Value::str(drop_last(rest)), None));
+                    }
+                }
+
+                part = part.replace("$$", "$");
+
+                if part.is_empty() {
+                    let mut ascends = 0i64;
+                    while parts.get(1 + p_i).map(|s| s.is_empty()).unwrap_or(false) {
+                        ascends += 1;
+                        p_i += 1;
+                    }
+
+                    if injdef.is_some() && ascends > 0 {
+                        if p_i == parts.len() - 1 {
+                            ascends -= 1;
+                        }
+                        if ascends == 0 {
+                            val = dparent.clone();
+                        } else {
+                            // fullpath = slice(dpath, -ascends) ++ parts[p_i+1..]
+                            let head = slice(
+                                Value::list(dpath.iter().cloned().map(Value::Str).collect()),
+                                Some(-ascends),
+                                None,
+                                false,
+                            );
+                            let mut fullpath: Vec<String> = match &head {
+                                Value::List(l) => l
+                                    .borrow()
+                                    .iter()
+                                    .map(|x| x.as_str().map(|s| s.to_string()).unwrap_or_default())
+                                    .collect(),
+                                _ => Vec::new(),
+                            };
+                            fullpath.extend_from_slice(&parts[p_i + 1..]);
+                            if ascends <= dpath.len() as i64 {
+                                val = get_path_inj(
+                                    store,
+                                    &Value::list(
+                                        fullpath.into_iter().map(Value::Str).collect(),
+                                    ),
+                                    None,
+                                );
+                            } else {
+                                val = Value::Noval;
+                            }
+                            break;
+                        }
+                    } else {
+                        val = dparent.clone();
+                    }
+                } else {
+                    val = get_prop(&val, &Value::str(part), Value::Noval);
+                }
+
+                p_i += 1;
+            }
+        }
+    }
+
+    if let Some(inj) = injdef {
+        let handler = inj.borrow().handler.clone();
+        let r = pathify(path, None, None);
+        val = handler(inj, &val, &r, store);
+    }
+
+    val
+}
+
+fn drop_last(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.is_empty() {
+        String::new()
+    } else {
+        chars[..chars.len() - 1].iter().collect()
+    }
+}
+
+// ---------------------------------------------------------------------
+// setpath
+// ---------------------------------------------------------------------
+
+pub fn set_path(store: &Value, path: &Value, val: Value, injdef: Option<&InjectDef>) -> Value {
+    // Keep parts as Values so a numeric part (only possible when `path` is an
+    // array) makes its parent a list, while a string part makes a map.
+    let parts: Vec<Value> = match path {
+        Value::List(l) => l.borrow().clone(),
+        Value::Str(s) => s.split('.').map(Value::str).collect(),
+        Value::Num(n) => vec![Value::Num(*n)],
+        _ => return Value::Noval,
+    };
+    if parts.is_empty() {
+        return Value::Noval;
+    }
+
+    let base = injdef.and_then(|d| d.base.clone());
+    let numparts = parts.len();
+    let mut parent = match &base {
+        Some(b) => get_prop(store, &Value::str(b.clone()), store.clone()),
+        None => store.clone(),
+    };
+
+    for p_i in 0..numparts - 1 {
+        let part_key = parts[p_i].clone();
+        let next_parent = get_prop(&parent, &part_key, Value::Noval);
+        let next_parent = if !is_node(&next_parent) {
+            let next_is_num = parts
+                .get(p_i + 1)
+                .map(|p| typify(p) & (T_NUMBER as i64) != 0)
+                .unwrap_or(false);
+            let np = if next_is_num {
+                Value::empty_list()
+            } else {
+                Value::empty_map()
+            };
+            set_prop(parent.clone(), &part_key, np.clone());
+            np
+        } else {
+            next_parent
+        };
+        parent = next_parent;
+    }
+
+    let last = parts[numparts - 1].clone();
+    if val.is_delete() {
+        del_prop(parent.clone(), &last);
+    } else {
+        set_prop(parent.clone(), &last, val);
+    }
+
+    parent
+}
+
+// ---------------------------------------------------------------------
+// inject / transform / validate / select — staged (see rs/PLAN.md, NOTES.md)
+// ---------------------------------------------------------------------
+
+/// Default inject handler — passes the value through unless it's a `$NAME`
+/// command function (the full machinery is staged; see PLAN.md §8).
+pub fn inject_handler_fn() -> NativeFn {
+    Rc::new(|_inj: &Inj, val: &Value, _r: &str, _store: &Value| -> Value { val.clone() })
+}
+
+pub fn inject(_val: Value, _store: &Value, _injdef: Option<&InjectDef>) -> Value {
+    unimplemented!("inject: not yet ported — see rs/PLAN.md §8 and rs/NOTES.md")
+}
+
+pub fn transform(
+    _data: &Value,
+    _spec: &Value,
+    _injdef: Option<&InjectDef>,
+) -> Result<Value, StructError> {
+    unimplemented!("transform: not yet ported — see rs/PLAN.md §9 and rs/NOTES.md")
+}
+
+pub fn validate(
+    _data: &Value,
+    _spec: &Value,
+    _injdef: Option<&InjectDef>,
+) -> Result<Value, StructError> {
+    unimplemented!("validate: not yet ported — see rs/PLAN.md §10 and rs/NOTES.md")
+}
+
+pub fn select(_children: &Value, _query: &Value) -> Value {
+    unimplemented!("select: not yet ported — see rs/PLAN.md §11 and rs/NOTES.md")
+}
+
+pub fn check_placement(_modes: i64, _ijname: &str, _parent_types: i64, _inj: &Inj) -> bool {
+    unimplemented!()
+}
+
+pub fn injector_args(_arg_types: &[i64], _args: &[Value]) -> Vec<Value> {
+    unimplemented!()
+}
+
+pub fn inject_child(_child: Value, _store: &Value, _inj: &Inj) -> Inj {
+    unimplemented!()
+}
+
+// keep `Injection::has_handler` referenced (used once staging is complete)
+#[allow(dead_code)]
+fn _keepalive() {
+    let _ = Injection::has_handler(None);
+}

--- a/rs/src/major.rs
+++ b/rs/src/major.rs
@@ -328,6 +328,165 @@ impl Injection {
     fn has_handler(def: Option<&InjectDef>) -> bool {
         def.map(|d| d.handler.is_some()).unwrap_or(false)
     }
+
+    /// Fresh root injection: `val` wrapped in the virtual parent holder.
+    pub fn root(val: Value, parent: Value) -> Inj {
+        let parent_clone = parent.clone();
+        Rc::new(RefCell::new(Injection {
+            mode: M_VAL,
+            full: false,
+            key_i: 0,
+            keys: Rc::new(RefCell::new(vec![S_DTOP.to_string()])),
+            key: S_DTOP.to_string(),
+            val,
+            parent,
+            path: vec![S_DTOP.to_string()],
+            nodes: vec![parent_clone],
+            handler: inject_handler_fn(),
+            errs: Value::empty_list(),
+            meta: Value::empty_map(),
+            dparent: Value::Noval,
+            dpath: vec![S_DTOP.to_string()],
+            base: Some(S_DTOP.to_string()),
+            modify: None,
+            extra: None,
+            prior: None,
+        }))
+    }
+
+    pub fn descend(this: &Inj) {
+        // meta.__d++
+        {
+            let b = this.borrow();
+            if let Value::Map(m) = &b.meta {
+                let cur = m.borrow().get("__d").and_then(|v| v.as_num()).unwrap_or(0.0);
+                m.borrow_mut().insert("__d".to_string(), Value::Num(cur + 1.0));
+            }
+        }
+        let (parentkey, has_dparent, dpath_len, last_part) = {
+            let b = this.borrow();
+            let parentkey = if b.path.len() >= 2 {
+                Some(b.path[b.path.len() - 2].clone())
+            } else {
+                None
+            };
+            (parentkey, !b.dparent.is_noval(), b.dpath.len(), b.dpath.last().cloned())
+        };
+
+        if !has_dparent {
+            if dpath_len > 1 {
+                if let Some(pk) = parentkey {
+                    this.borrow_mut().dpath.push(pk);
+                }
+            }
+        } else if let Some(pk) = parentkey {
+            let newdparent = {
+                let b = this.borrow();
+                get_prop(&b.dparent, &Value::str(pk.clone()), Value::Noval)
+            };
+            let mut b = this.borrow_mut();
+            b.dparent = newdparent;
+            if last_part.as_deref() == Some(format!("$:{pk}").as_str()) {
+                let n = b.dpath.len();
+                b.dpath.truncate(n.saturating_sub(1));
+            } else {
+                b.dpath.push(pk);
+            }
+        }
+    }
+
+    pub fn child(this: &Inj, key_i: i64, keys: SVec) -> Inj {
+        let (key, parent_val, cval, path, nodes, mode, handler, modify, base, meta, errs, dpath, dparent) = {
+            let b = this.borrow();
+            let key = str_key(
+                keys.borrow()
+                    .get(key_i.max(0) as usize)
+                    .cloned()
+                    .map(Value::Str)
+                    .unwrap_or(Value::Noval),
+            );
+            let parent_val = b.val.clone();
+            let cval = get_prop(&parent_val, &Value::str(key.clone()), Value::Noval);
+            let mut path = b.path.clone();
+            path.push(key.clone());
+            let mut nodes = b.nodes.clone();
+            nodes.push(parent_val.clone());
+            (
+                key,
+                parent_val,
+                cval,
+                path,
+                nodes,
+                b.mode,
+                b.handler.clone(),
+                b.modify.clone(),
+                b.base.clone(),
+                b.meta.clone(),
+                b.errs.clone(),
+                b.dpath.clone(),
+                b.dparent.clone(),
+            )
+        };
+        Rc::new(RefCell::new(Injection {
+            mode,
+            full: false,
+            key_i,
+            keys,
+            key,
+            val: cval,
+            parent: parent_val,
+            path,
+            nodes,
+            handler,
+            errs,
+            meta,
+            dparent,
+            dpath,
+            base,
+            modify,
+            extra: None,
+            prior: Some(Rc::clone(this)),
+        }))
+    }
+
+    pub fn setval(this: &Inj, val: Value, ancestor: Option<i64>) -> Value {
+        let anc = ancestor.unwrap_or(0);
+        if anc < 2 {
+            let (parent, key) = {
+                let b = this.borrow();
+                (b.parent.clone(), b.key.clone())
+            };
+            if val.is_noval() {
+                let np = del_prop(parent, &Value::str(key));
+                this.borrow_mut().parent = np.clone();
+                np
+            } else {
+                set_prop(parent, &Value::str(key), val)
+            }
+        } else {
+            let (aval, akey) = {
+                let b = this.borrow();
+                let n = b.nodes.len() as i64;
+                let aval = if n - anc >= 0 {
+                    b.nodes[(n - anc) as usize].clone()
+                } else {
+                    Value::Noval
+                };
+                let pn = b.path.len() as i64;
+                let akey = if pn - anc >= 0 {
+                    b.path[(pn - anc) as usize].clone()
+                } else {
+                    String::new()
+                };
+                (aval, akey)
+            };
+            if val.is_noval() {
+                del_prop(aval, &Value::str(akey))
+            } else {
+                set_prop(aval, &Value::str(akey), val)
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -546,22 +705,492 @@ pub fn set_path(store: &Value, path: &Value, val: Value, injdef: Option<&InjectD
 // inject / transform / validate / select — staged (see rs/PLAN.md, NOTES.md)
 // ---------------------------------------------------------------------
 
-/// Default inject handler — passes the value through unless it's a `$NAME`
-/// command function (the full machinery is staged; see PLAN.md §8).
+/// Default inject handler (`_injecthandler`): if the value is a `$NAME`
+/// command function, call it; otherwise, in `val` mode for a full-string
+/// injection, write the value back into the parent.
 pub fn inject_handler_fn() -> NativeFn {
-    Rc::new(|_inj: &Inj, val: &Value, _r: &str, _store: &Value| -> Value { val.clone() })
+    Rc::new(inject_handler)
 }
 
-pub fn inject(_val: Value, _store: &Value, _injdef: Option<&InjectDef>) -> Value {
-    unimplemented!("inject: not yet ported — see rs/PLAN.md §8 and rs/NOTES.md")
+fn inject_handler(inj: &Inj, val: &Value, r: &str, store: &Value) -> Value {
+    let iscmd = is_func(val) && (r.is_empty() || r.starts_with('$'));
+    if iscmd {
+        if let Value::Func(f) = val {
+            return f(inj, val, r, store);
+        }
+    }
+    let (mode, full) = {
+        let b = inj.borrow();
+        (b.mode, b.full)
+    };
+    if mode == M_VAL && full {
+        Injection::setval(inj, val.clone(), None);
+    }
+    val.clone()
+}
+
+/// `_injectstr` — substitute `` `path` `` references inside a string.
+fn injectstr(val: &str, store: &Value, inj: Option<&Inj>) -> Value {
+    if val.is_empty() {
+        return Value::str("");
+    }
+
+    if let Some(caps) = R_INJECTION_FULL.captures(val) {
+        if let Some(i) = inj {
+            i.borrow_mut().full = true;
+        }
+        let mut pathref = caps[1].to_string();
+        if pathref.chars().count() > 3 {
+            pathref = pathref.replace("$BT", S_BT).replace("$DS", S_DS);
+        }
+        return get_path_inj(store, &Value::str(pathref), inj);
+    }
+
+    // partial injection: replace each `ref` occurrence
+    let out_str = R_INJECTION_PARTIAL
+        .replace_all(val, |caps: &regex::Captures| -> String {
+            let mut r = caps[1].to_string();
+            if r.chars().count() > 3 {
+                r = r.replace("$BT", S_BT).replace("$DS", S_DS);
+            }
+            if let Some(i) = inj {
+                i.borrow_mut().full = false;
+            }
+            let found = get_path_inj(store, &Value::str(r), inj);
+            match &found {
+                Value::Noval => String::new(),
+                Value::Str(s) => s.clone(),
+                other => jsonify(other, Some(&JsonFlags { indent: 0, offset: 0 })),
+            }
+        })
+        .to_string();
+
+    if let Some(i) = inj {
+        let handler = {
+            i.borrow_mut().full = true;
+            i.borrow().handler.clone()
+        };
+        return handler(i, &Value::str(out_str), val, store);
+    }
+    Value::str(out_str)
+}
+
+pub fn inject(val: Value, store: &Value, injdef: Option<&InjectDef>) -> Value {
+    let inj = make_root_injection(val.clone(), store, injdef);
+    inject_inj(val, store, &inj)
+}
+
+/// Build the root injection for a top-level `inject` (mirrors the TS setup
+/// block when `injdef.mode == null`).
+fn make_root_injection(val: Value, store: &Value, injdef: Option<&InjectDef>) -> Inj {
+    let mut top = indexmap::IndexMap::new();
+    top.insert(S_DTOP.to_string(), val.clone());
+    let inj = Injection::root(val, Value::map(top));
+    {
+        let mut b = inj.borrow_mut();
+        b.dparent = store.clone();
+        let store_errs = get_prop(store, &Value::str(S_DERRS), Value::Noval);
+        if !store_errs.is_noval() {
+            b.errs = store_errs;
+        }
+        if let Value::Map(m) = &b.meta {
+            m.borrow_mut().insert("__d".to_string(), Value::Num(0.0));
+        }
+        if let Some(d) = injdef {
+            if let Some(x) = &d.modify {
+                b.modify = Some(x.clone());
+            }
+            if let Some(x) = &d.extra {
+                b.extra = Some(x.clone());
+            }
+            if let Some(x) = &d.meta {
+                b.meta = x.clone();
+            }
+            if let Some(x) = &d.handler {
+                b.handler = x.clone();
+            }
+        }
+    }
+    inj
+}
+
+/// Recursive `inject` working against an existing injection.
+// `nk_i` is re-read after every child phase to match the canonical loop
+// (an injector in the M_VAL phase, e.g. $REF, may change `key_i`).
+#[allow(unused_assignments)]
+fn inject_inj(mut val: Value, store: &Value, inj: &Inj) -> Value {
+    Injection::descend(inj);
+
+    if is_node(&val) {
+        // node keys: sorted, then `$`-bearing keys last (for maps).
+        let nodekeys: SVec = {
+            let ks = keysof_vec(&val);
+            if is_map(&val) {
+                let (mut plain, dollar): (Vec<String>, Vec<String>) =
+                    ks.into_iter().partition(|k| !k.contains(S_DS));
+                plain.extend(dollar);
+                Rc::new(RefCell::new(plain))
+            } else {
+                Rc::new(RefCell::new(ks))
+            }
+        };
+
+        let mut nk_i: i64 = 0;
+        loop {
+            if nk_i < 0 {
+                nk_i += 1;
+                continue;
+            }
+            if nk_i as usize >= nodekeys.borrow().len() {
+                break;
+            }
+
+            let childinj = Injection::child(inj, nk_i, nodekeys.clone());
+            let nodekey = childinj.borrow().key.clone();
+            childinj.borrow_mut().mode = M_KEYPRE;
+
+            let prekey = injectstr(&nodekey, store, Some(&childinj));
+            nk_i = childinj.borrow().key_i;
+            // (keys may have been replaced by an injector — `nodekeys` itself
+            // is the shared Rc, so re-reading is implicit.)
+
+            if !prekey.is_noval() {
+                let cval = get_prop(&val, &prekey, Value::Noval);
+                {
+                    let mut b = childinj.borrow_mut();
+                    b.val = cval.clone();
+                    b.mode = M_VAL;
+                }
+                inject_inj(cval, store, &childinj);
+                nk_i = childinj.borrow().key_i;
+
+                childinj.borrow_mut().mode = M_KEYPOST;
+                injectstr(&nodekey, store, Some(&childinj));
+                nk_i = childinj.borrow().key_i;
+            }
+
+            nk_i += 1;
+        }
+    } else if let Value::Str(s) = val.clone() {
+        inj.borrow_mut().mode = M_VAL;
+        let r = injectstr(&s, store, Some(inj));
+        val = r.clone();
+        if !val.is_skip() {
+            Injection::setval(inj, val.clone(), None);
+        }
+    }
+
+    // custom modification
+    let modify = inj.borrow().modify.clone();
+    if let Some(m) = modify {
+        if !val.is_skip() {
+            let (mkey, mparent) = {
+                let b = inj.borrow();
+                (b.key.clone(), b.parent.clone())
+            };
+            let mval = get_prop(&mparent, &Value::str(mkey.clone()), Value::Noval);
+            m(&mval, &Value::str(mkey), &mparent, inj, store);
+        }
+    }
+
+    inj.borrow_mut().val = val;
+    let parent = inj.borrow().parent.clone();
+    get_prop(&parent, &Value::str(S_DTOP), Value::Noval)
+}
+
+// ---- transform commands ----------------------------------------------
+
+const T_ANY_I: i64 = T_ANY as i64;
+
+fn errs_push(inj: &Inj, msg: String) {
+    let errs = inj.borrow().errs.clone();
+    if let Value::List(l) = &errs {
+        l.borrow_mut().push(Value::Str(msg));
+    }
+}
+
+fn placement_str(mode: i64) -> &'static str {
+    match mode {
+        M_VAL => "value",
+        M_KEYPRE | M_KEYPOST => "key",
+        _ => "",
+    }
+}
+
+pub fn check_placement(modes: i64, ijname: &str, parent_types: i64, inj: &Inj) -> bool {
+    let (mode, parent) = {
+        let b = inj.borrow();
+        (b.mode, b.parent.clone())
+    };
+    if modes & mode == 0 {
+        let expected: Vec<&str> = [M_KEYPRE, M_KEYPOST, M_VAL]
+            .iter()
+            .filter(|m| modes & **m != 0)
+            .map(|m| placement_str(*m))
+            .collect();
+        errs_push(
+            inj,
+            format!(
+                "${ijname}: invalid placement as {}, expected: {}.",
+                placement_str(mode),
+                expected.join(",")
+            ),
+        );
+        return false;
+    }
+    if !is_empty(&Value::Num(parent_types as f64)) {
+        let ptype = typify(&parent);
+        if parent_types & ptype == 0 {
+            errs_push(
+                inj,
+                format!(
+                    "${ijname}: invalid placement in parent {}, expected: {}.",
+                    type_name(ptype),
+                    type_name(parent_types)
+                ),
+            );
+            return false;
+        }
+    }
+    true
+}
+
+pub fn injector_args(arg_types: &[i64], args: &[Value]) -> Vec<Value> {
+    let mut found: Vec<Value> = Vec::with_capacity(1 + arg_types.len());
+    found.push(Value::Noval);
+    for (i, at) in arg_types.iter().enumerate() {
+        let arg = args.get(i).cloned().unwrap_or(Value::Noval);
+        let argtype = typify(&arg);
+        if at & argtype == 0 {
+            found[0] = Value::str(format!(
+                "invalid argument: {} ({} at position {}) is not of type: {}.",
+                stringify(&arg, Some(22), false),
+                type_name(argtype),
+                1 + i,
+                type_name(*at)
+            ));
+            return found;
+        }
+        found.push(arg);
+    }
+    found
+}
+
+pub fn inject_child(_child: Value, _store: &Value, _inj: &Inj) -> Inj {
+    unimplemented!("injectChild: used by $FORMAT/$APPLY — staged")
+}
+
+fn transform_delete(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    Injection::setval(inj, Value::Noval, None);
+    Value::Noval
+}
+
+fn transform_copy(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    if !check_placement(M_VAL, "COPY", T_ANY_I, inj) {
+        return Value::Noval;
+    }
+    let (dparent, key) = {
+        let b = inj.borrow();
+        (b.dparent.clone(), b.key.clone())
+    };
+    let out = get_prop(&dparent, &Value::str(key), Value::Noval);
+    Injection::setval(inj, out.clone(), None);
+    out
+}
+
+fn transform_key(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (mode, parent, dparent, anno_key) = {
+        let b = inj.borrow();
+        let anno_key = b.path.get(b.path.len().saturating_sub(2)).cloned();
+        (b.mode, b.parent.clone(), b.dparent.clone(), anno_key)
+    };
+    if mode != M_VAL {
+        return Value::Noval;
+    }
+    let keyspec = get_prop(&parent, &Value::str(S_BKEY), Value::Noval);
+    if !keyspec.is_noval() {
+        del_prop(parent.clone(), &Value::str(S_BKEY));
+        return get_prop(&dparent, &keyspec, Value::Noval);
+    }
+    let anno = get_prop(&parent, &Value::str(S_BANNO), Value::Noval);
+    get_prop(
+        &anno,
+        &Value::str(S_KEY),
+        anno_key.map(Value::Str).unwrap_or(Value::Noval),
+    )
+}
+
+fn transform_anno(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let parent = inj.borrow().parent.clone();
+    del_prop(parent, &Value::str(S_BANNO));
+    Value::Noval
+}
+
+fn transform_merge(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (mode, key, parent) = {
+        let b = inj.borrow();
+        (b.mode, b.key.clone(), b.parent.clone())
+    };
+    let mut out = Value::Noval;
+    if mode == M_KEYPRE {
+        out = Value::str(key);
+    } else if mode == M_KEYPOST {
+        out = Value::str(key.clone());
+        let mut args = get_prop(&parent, &Value::str(key.clone()), Value::Noval);
+        if !is_list(&args) {
+            args = Value::list(vec![args]);
+        }
+        Injection::setval(inj, Value::Noval, None); // remove $MERGE key from parent
+        let args_vec: Vec<Value> = args.as_list().map(|l| l.borrow().clone()).unwrap_or_default();
+        let mut mergelist: Vec<Value> = vec![parent.clone()];
+        mergelist.extend(args_vec);
+        mergelist.push(clone(&parent));
+        merge(&Value::list(mergelist), Some(1));
+    }
+    out
+}
+
+fn transform_unsupported(name: &'static str) -> impl Fn(&Inj, &Value, &str, &Value) -> Value {
+    move |inj: &Inj, _v: &Value, _r: &str, _store: &Value| -> Value {
+        errs_push(inj, format!("${name}: not yet ported in the Rust port."));
+        Value::Noval
+    }
 }
 
 pub fn transform(
-    _data: &Value,
-    _spec: &Value,
-    _injdef: Option<&InjectDef>,
+    data: &Value,
+    spec: &Value,
+    injdef: Option<&InjectDef>,
 ) -> Result<Value, StructError> {
-    unimplemented!("transform: not yet ported — see rs/PLAN.md §9 and rs/NOTES.md")
+    let origspec = spec.clone();
+    let spec_clone = clone(&origspec);
+
+    let extra = injdef.and_then(|d| d.extra.clone());
+    let collect = injdef.map(|d| d.errs.is_some()).unwrap_or(false);
+    let errs = injdef
+        .and_then(|d| d.errs.clone())
+        .unwrap_or_else(Value::empty_list);
+
+    // split `extra` into data-extras (non-$) and transform-extras ($)
+    let mut extra_transforms = indexmap::IndexMap::new();
+    let extra_data: Value = match &extra {
+        None => Value::Noval,
+        Some(e) => {
+            let mut a = indexmap::IndexMap::new();
+            for (k, v) in items_vec(e) {
+                if k.starts_with(S_DS) {
+                    extra_transforms.insert(k, v);
+                } else {
+                    a.insert(k, v);
+                }
+            }
+            Value::map(a)
+        }
+    };
+
+    let data_clone = merge(
+        &Value::list(vec![
+            if is_empty(&extra_data) {
+                Value::Noval
+            } else {
+                clone(&extra_data)
+            },
+            clone(data),
+        ]),
+        None,
+    );
+
+    // build the transform store
+    let origspec_for_thunk = origspec.clone();
+    let mut store_base: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+    store_base.insert(S_DTOP.to_string(), data_clone);
+    store_base.insert(
+        "$SPEC".to_string(),
+        Value::func(move |_i: &Inj, _v: &Value, _r: &str, _s: &Value| origspec_for_thunk.clone()),
+    );
+    store_base.insert(
+        "$BT".to_string(),
+        Value::func(|_i: &Inj, _v: &Value, _r: &str, _s: &Value| Value::str(S_BT)),
+    );
+    store_base.insert(
+        "$DS".to_string(),
+        Value::func(|_i: &Inj, _v: &Value, _r: &str, _s: &Value| Value::str(S_DS)),
+    );
+    store_base.insert(
+        "$WHEN".to_string(),
+        Value::func(|_i: &Inj, _v: &Value, _r: &str, _s: &Value| Value::str(iso_now())),
+    );
+    store_base.insert("$DELETE".to_string(), Value::func(transform_delete));
+    store_base.insert("$COPY".to_string(), Value::func(transform_copy));
+    store_base.insert("$KEY".to_string(), Value::func(transform_key));
+    store_base.insert("$ANNO".to_string(), Value::func(transform_anno));
+    store_base.insert("$MERGE".to_string(), Value::func(transform_merge));
+    store_base.insert("$EACH".to_string(), Value::func(transform_unsupported("EACH")));
+    store_base.insert("$PACK".to_string(), Value::func(transform_unsupported("PACK")));
+    store_base.insert("$REF".to_string(), Value::func(transform_unsupported("REF")));
+    store_base.insert(
+        "$FORMAT".to_string(),
+        Value::func(transform_unsupported("FORMAT")),
+    );
+    store_base.insert(
+        "$APPLY".to_string(),
+        Value::func(transform_unsupported("APPLY")),
+    );
+
+    let store = merge(
+        &Value::list(vec![
+            Value::map(store_base),
+            Value::map(extra_transforms),
+            Value::map_of([(S_DERRS.to_string(), errs.clone())]),
+        ]),
+        Some(1),
+    );
+
+    let out = inject(spec_clone, &store, injdef);
+
+    let errlen = errs.as_list().map(|l| l.borrow().len()).unwrap_or(0);
+    if errlen > 0 && !collect {
+        let msgs: Vec<String> = errs
+            .as_list()
+            .map(|l| l.borrow().iter().map(|e| js_string(e)).collect())
+            .unwrap_or_default();
+        return Err(StructError {
+            message: msgs.join(" | "),
+        });
+    }
+
+    Ok(out)
+}
+
+fn iso_now() -> String {
+    // best-effort ISO-8601 UTC string; the corpus can't assert the exact
+    // value (it changes), so granularity to the second is fine.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let dur = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    let secs = dur.as_secs() as i64;
+    let millis = dur.subsec_millis();
+    // days since 1970-01-01
+    let days = secs.div_euclid(86_400);
+    let tod = secs.rem_euclid(86_400);
+    let (h, m, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let (y, mo, d) = civil_from_days(days);
+    format!(
+        "{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}.{millis:03}Z"
+    )
+}
+
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    // Howard Hinnant's algorithm.
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
 pub fn validate(
@@ -576,20 +1205,9 @@ pub fn select(_children: &Value, _query: &Value) -> Value {
     unimplemented!("select: not yet ported — see rs/PLAN.md §11 and rs/NOTES.md")
 }
 
-pub fn check_placement(_modes: i64, _ijname: &str, _parent_types: i64, _inj: &Inj) -> bool {
-    unimplemented!()
-}
-
-pub fn injector_args(_arg_types: &[i64], _args: &[Value]) -> Vec<Value> {
-    unimplemented!()
-}
-
-pub fn inject_child(_child: Value, _store: &Value, _inj: &Inj) -> Inj {
-    unimplemented!()
-}
-
 // keep `Injection::has_handler` referenced (used once staging is complete)
 #[allow(dead_code)]
 fn _keepalive() {
     let _ = Injection::has_handler(None);
+    let _ = inject_child as fn(Value, &Value, &Inj) -> Inj;
 }

--- a/rs/src/major.rs
+++ b/rs/src/major.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 
 use crate::consts::*;
 use crate::mini::*;
-use crate::value::{js_string, Value};
+use crate::value::{js_string, js_to_int32, js_to_number, Value};
 use crate::StructError;
 
 // ---------------------------------------------------------------------
@@ -976,8 +976,196 @@ pub fn injector_args(arg_types: &[i64], args: &[Value]) -> Vec<Value> {
     found
 }
 
-pub fn inject_child(_child: Value, _store: &Value, _inj: &Inj) -> Inj {
-    unimplemented!("injectChild: used by $FORMAT/$APPLY — staged")
+pub fn inject_child(child: Value, store: &Value, inj: &Inj) -> Inj {
+    let prior = inj.borrow().prior.clone();
+    let cinj: Inj = match prior {
+        None => Rc::clone(inj),
+        Some(p) => {
+            let pprior = p.borrow().prior.clone();
+            match pprior {
+                Some(pp) => {
+                    let (pki, pkeys, pkey) = {
+                        let b = p.borrow();
+                        (b.key_i, b.keys.clone(), b.key.clone())
+                    };
+                    let c = Injection::child(&pp, pki, pkeys);
+                    c.borrow_mut().val = child.clone();
+                    let cparent = c.borrow().parent.clone();
+                    set_prop(cparent, &Value::str(pkey), child.clone());
+                    c
+                }
+                None => {
+                    let (ki, keys, key) = {
+                        let b = inj.borrow();
+                        (b.key_i, b.keys.clone(), b.key.clone())
+                    };
+                    let c = Injection::child(&p, ki, keys);
+                    c.borrow_mut().val = child.clone();
+                    let cparent = c.borrow().parent.clone();
+                    set_prop(cparent, &Value::str(key), child.clone());
+                    c
+                }
+            }
+        }
+    };
+    let _ = inject_inj(child, store, &cinj);
+    cinj
+}
+
+const FORMATTER_NAMES: [&str; 7] =
+    ["identity", "upper", "lower", "string", "number", "integer", "concat"];
+
+fn apply_formatter(name: &str, k: &Value, v: &Value) -> Value {
+    match name {
+        "identity" => v.clone(),
+        "upper" => {
+            if is_node(v) {
+                v.clone()
+            } else {
+                Value::str(js_string(v).to_uppercase())
+            }
+        }
+        "lower" => {
+            if is_node(v) {
+                v.clone()
+            } else {
+                Value::str(js_string(v).to_lowercase())
+            }
+        }
+        "string" => {
+            if is_node(v) {
+                v.clone()
+            } else {
+                Value::str(js_string(v))
+            }
+        }
+        "number" => {
+            if is_node(v) {
+                v.clone()
+            } else {
+                let n = js_to_number(v);
+                Value::Num(if n.is_nan() { 0.0 } else { n })
+            }
+        }
+        "integer" => {
+            if is_node(v) {
+                v.clone()
+            } else {
+                let n = js_to_number(v);
+                let n = if n.is_nan() { 0.0 } else { n };
+                Value::Num(js_to_int32(n) as f64)
+            }
+        }
+        "concat" => {
+            if k.is_noval() && is_list(v) {
+                Value::str(
+                    items_vec(v)
+                        .iter()
+                        .map(|(_, n)| if is_node(n) { String::new() } else { js_string(n) })
+                        .collect::<Vec<_>>()
+                        .join(""),
+                )
+            } else {
+                v.clone()
+            }
+        }
+        _ => v.clone(),
+    }
+}
+
+// `$FORMAT` — render a templated value through a named (or supplied) formatter.
+fn transform_format(inj: &Inj, _val: &Value, _r: &str, store: &Value) -> Value {
+    inj.borrow().keys.borrow_mut().truncate(1);
+    if inj.borrow().mode != M_VAL {
+        return Value::Noval;
+    }
+    let (parent, path, nodes) = {
+        let b = inj.borrow();
+        (b.parent.clone(), b.path.clone(), b.nodes.clone())
+    };
+    let name = get_prop(&parent, &Value::Num(1.0), Value::Noval);
+    let child = get_prop(&parent, &Value::Num(2.0), Value::Noval);
+    let tkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let nlen = nodes.len();
+    let target = if nlen >= 2 {
+        nodes[nlen - 2].clone()
+    } else if nlen >= 1 {
+        nodes[nlen - 1].clone()
+    } else {
+        Value::Noval
+    };
+
+    let cinj = inject_child(child, store, inj);
+    let resolved = cinj.borrow().val.clone();
+
+    let fname: Option<String> = name
+        .as_str()
+        .filter(|n| FORMATTER_NAMES.contains(n))
+        .map(|s| s.to_string());
+    if fname.is_none() && !is_func(&name) {
+        errs_push(inj, format!("$FORMAT: unknown format: {}.", js_string(&name)));
+        return Value::Noval;
+    }
+
+    let out = if let Some(fn_name) = &fname {
+        let mut fmt = |k: &Value, v: &Value, _p: &Value, _t: &[String]| -> Value {
+            apply_formatter(fn_name, k, v)
+        };
+        walk(resolved, Some(&mut fmt), None, None)
+    } else if let Value::Func(f) = &name {
+        let f = f.clone();
+        let mut fmt = |_k: &Value, v: &Value, _p: &Value, _t: &[String]| -> Value {
+            f(inj, v, "", store)
+        };
+        walk(resolved, Some(&mut fmt), None, None)
+    } else {
+        resolved
+    };
+
+    set_prop(target, &Value::str(tkey), out.clone());
+    out
+}
+
+// `$APPLY` — call a function (from the spec args) on the resolved child.
+fn transform_apply(inj: &Inj, _val: &Value, _r: &str, store: &Value) -> Value {
+    if !check_placement(M_VAL, "APPLY", T_LIST as i64, inj) {
+        return Value::Noval;
+    }
+    let (parent, path, nodes) = {
+        let b = inj.borrow();
+        (b.parent.clone(), b.path.clone(), b.nodes.clone())
+    };
+    let args: Vec<Value> = slice(parent.clone(), Some(1), None, false)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    let ia = injector_args(&[T_FUNCTION as i64, T_ANY as i64], &args);
+    if let Value::Str(e) = &ia[0] {
+        errs_push(inj, format!("$APPLY: {e}"));
+        return Value::Noval;
+    }
+    let apply = ia.get(1).cloned().unwrap_or(Value::Noval);
+    let child = ia.get(2).cloned().unwrap_or(Value::Noval);
+    let tkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let nlen = nodes.len();
+    let target = if nlen >= 2 {
+        nodes[nlen - 2].clone()
+    } else if nlen >= 1 {
+        nodes[nlen - 1].clone()
+    } else {
+        Value::Noval
+    };
+    let cinj = inject_child(child, store, inj);
+    let resolved = cinj.borrow().val.clone();
+    // The corpus only exercises the error paths; if `apply` is a callable, do
+    // a best-effort call (the canonical passes (resolved, store, cinj)).
+    let out = if let Value::Func(f) = &apply {
+        f(&cinj, &resolved, "", store)
+    } else {
+        resolved
+    };
+    set_prop(target, &Value::str(tkey), out.clone());
+    out
 }
 
 fn transform_delete(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
@@ -1050,11 +1238,348 @@ fn transform_merge(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
     out
 }
 
-fn transform_unsupported(name: &'static str) -> impl Fn(&Inj, &Value, &str, &Value) -> Value {
-    move |inj: &Inj, _v: &Value, _r: &str, _store: &Value| -> Value {
-        errs_push(inj, format!("${name}: not yet ported in the Rust port."));
-        Value::Noval
+fn slice_str_vec(v: &[String], start: Option<i64>, end: Option<i64>) -> Vec<String> {
+    match slice(path_value(v), start, end, false) {
+        Value::List(l) => l
+            .borrow()
+            .iter()
+            .map(|x| x.as_str().map(|s| s.to_string()).unwrap_or_default())
+            .collect(),
+        _ => Vec::new(),
     }
+}
+
+// `$REF` — reference the original spec (enables recursive transforms).
+fn transform_ref(inj: &Inj, val: &Value, _r: &str, store: &Value) -> Value {
+    let (mode, parent, path, nodes) = {
+        let b = inj.borrow();
+        (b.mode, b.parent.clone(), b.path.clone(), b.nodes.clone())
+    };
+    if mode != M_VAL {
+        return Value::Noval;
+    }
+    let refpath = get_prop(&parent, &Value::Num(1.0), Value::Noval);
+    {
+        let keylen = inj.borrow().keys.borrow().len() as i64;
+        inj.borrow_mut().key_i = keylen;
+    }
+    // spec = ($SPEC)()
+    let spec = {
+        let sf = get_prop(store, &Value::str(S_DSPEC), Value::Noval);
+        match &sf {
+            Value::Func(f) => f(inj, &Value::Noval, "", store),
+            _ => Value::Noval,
+        }
+    };
+    let dpath = slice_str_vec(&path, Some(1), None);
+    let dparent_for_ref = get_path_inj(&spec, &path_value(&dpath), None);
+    let ref_def = InjectDef {
+        dpath: Some(dpath.clone()),
+        dparent: Some(dparent_for_ref),
+        ..Default::default()
+    };
+    let refval = get_path(&spec, &refpath, Some(&ref_def));
+
+    let mut has_sub_ref = false;
+    if is_node(&refval) {
+        let mut probe = |_k: &Value, v: &Value, _p: &Value, _t: &[String]| -> Value {
+            if matches!(v, Value::Str(s) if s == "`$REF`") {
+                has_sub_ref = true;
+            }
+            v.clone()
+        };
+        walk(refval.clone(), Some(&mut probe), None, None);
+    }
+
+    let tref = clone(&refval);
+    let cpath = slice_str_vec(&path, Some(-3), None);
+    let tpath = slice_str_vec(&path, Some(-1), None);
+    let tcur = get_path_inj(store, &path_value(&cpath), None);
+    let tval_at = get_path_inj(store, &path_value(&tpath), None);
+
+    let rval = if !has_sub_ref || !tval_at.is_noval() {
+        let tinj = Injection::child(
+            inj,
+            0,
+            Rc::new(RefCell::new(vec![tpath.last().cloned().unwrap_or_default()])),
+        );
+        {
+            let mut b = tinj.borrow_mut();
+            b.path = tpath.clone();
+            let nlen = nodes.len();
+            b.nodes = if nlen >= 1 { nodes[..nlen - 1].to_vec() } else { Vec::new() };
+            b.parent = if nlen >= 2 { nodes[nlen - 2].clone() } else { Value::Noval };
+            b.val = tref.clone();
+            b.dpath = cpath.clone();
+            b.dparent = tcur.clone();
+        }
+        let _ = inject_inj(tref.clone(), store, &tinj);
+        let v = tinj.borrow().val.clone();
+        v
+    } else {
+        Value::Noval
+    };
+
+    let grandparent = Injection::setval(inj, rval, Some(2));
+    if is_list(&grandparent) {
+        let prior = inj.borrow().prior.clone();
+        if let Some(p) = prior {
+            p.borrow_mut().key_i -= 1;
+        }
+    }
+    val.clone()
+}
+
+fn srcpath_split(srcpath: &str) -> Vec<String> {
+    srcpath.split('.').map(|s| s.to_string()).collect()
+}
+
+// `$EACH` — apply a child template to every entry of a list or map.
+// Spec form (a list): ['`$EACH`', 'source-path', child-template]
+fn transform_each(inj: &Inj, _val: &Value, _r: &str, store: &Value) -> Value {
+    if !check_placement(M_VAL, "EACH", T_LIST as i64, inj) {
+        return Value::Noval;
+    }
+    // remove remaining keys to avoid spurious processing
+    inj.borrow().keys.borrow_mut().truncate(1);
+
+    let (parent, path, nodes, base) = {
+        let b = inj.borrow();
+        (b.parent.clone(), b.path.clone(), b.nodes.clone(), b.base.clone())
+    };
+    let args: Vec<Value> = slice(parent.clone(), Some(1), None, false)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    let ia = injector_args(&[T_STRING as i64, T_ANY as i64], &args);
+    if let Value::Str(e) = &ia[0] {
+        errs_push(inj, format!("$EACH: {e}"));
+        return Value::Noval;
+    }
+    let srcpath = ia.get(1).cloned().unwrap_or(Value::Noval);
+    let child = ia.get(2).cloned().unwrap_or(Value::Noval);
+    let srcpath_str = srcpath.as_str().unwrap_or("").to_string();
+
+    let srcstore = get_prop(store, &Value::str(base.clone().unwrap_or_default()), store.clone());
+    let src = get_path_inj(&srcstore, &srcpath, Some(inj));
+    let srctype = typify(&src);
+
+    let tkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let nlen = nodes.len();
+    let target = if nlen >= 2 {
+        nodes[nlen - 2].clone()
+    } else if nlen >= 1 {
+        nodes[nlen - 1].clone()
+    } else {
+        Value::Noval
+    };
+
+    let tval: Vec<Value> = if srctype & (T_LIST as i64) != 0 {
+        items_vec(&src).iter().map(|_| clone(&child)).collect()
+    } else if srctype & (T_MAP as i64) != 0 {
+        items_vec(&src)
+            .iter()
+            .map(|(k, _)| {
+                merge(
+                    &Value::list(vec![
+                        clone(&child),
+                        Value::map_of([(
+                            S_BANNO.to_string(),
+                            Value::map_of([(S_KEY.to_string(), Value::str(k.clone()))]),
+                        )]),
+                    ]),
+                    Some(1),
+                )
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let mut rval = Value::empty_list();
+    if !tval.is_empty() {
+        let tcur_inner: Value = if src.is_nullish() {
+            Value::Noval
+        } else {
+            Value::list(items_vec(&src).into_iter().map(|(_, v)| v).collect())
+        };
+        let ckey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+        let tpath = slice_str_vec(&path, Some(-1), None);
+        let mut dpath: Vec<String> = vec![S_DTOP.to_string()];
+        dpath.extend(srcpath_split(&srcpath_str));
+        dpath.push(format!("$:{ckey}"));
+
+        let mut tcur = Value::map_of([(ckey.clone(), tcur_inner)]);
+        if tpath.len() > 1 {
+            let pkey = path
+                .get(path.len().saturating_sub(3))
+                .cloned()
+                .unwrap_or_else(|| S_DTOP.to_string());
+            tcur = Value::map_of([(pkey.clone(), tcur)]);
+            dpath.push(format!("$:{pkey}"));
+        }
+
+        let tval_v = Value::list(tval);
+        let tinj = Injection::child(inj, 0, Rc::new(RefCell::new(vec![ckey.clone()])));
+        {
+            let mut b = tinj.borrow_mut();
+            b.path = tpath;
+            b.nodes = if nlen >= 1 { nodes[..nlen - 1].to_vec() } else { Vec::new() };
+            b.parent = b.nodes.last().cloned().unwrap_or(Value::Noval);
+            b.val = tval_v.clone();
+            b.dpath = dpath;
+            b.dparent = tcur;
+        }
+        let pclone = tinj.borrow().parent.clone();
+        set_prop(pclone, &Value::str(ckey), tval_v.clone());
+        let _ = inject_inj(tval_v.clone(), store, &tinj);
+        rval = tinj.borrow().val.clone();
+    }
+
+    set_prop(target, &Value::str(tkey), rval.clone());
+    get_prop(&rval, &Value::Num(0.0), Value::Noval)
+}
+
+// `$PACK` — repack a list/map into a map keyed by `$KEY`.
+// Spec form (a map): { '`$PACK`': ['source-path', child-template] }
+fn transform_pack(inj: &Inj, _val: &Value, _r: &str, store: &Value) -> Value {
+    if !check_placement(M_KEYPRE, "EACH", T_MAP as i64, inj) {
+        return Value::Noval;
+    }
+    let (key, parent, path, nodes, base) = {
+        let b = inj.borrow();
+        (b.key.clone(), b.parent.clone(), b.path.clone(), b.nodes.clone(), b.base.clone())
+    };
+    let args = get_prop(&parent, &Value::str(key), Value::Noval);
+    let args_vec: Vec<Value> = args.as_list().map(|l| l.borrow().clone()).unwrap_or_default();
+    let ia = injector_args(&[T_STRING as i64, T_ANY as i64], &args_vec);
+    if let Value::Str(e) = &ia[0] {
+        errs_push(inj, format!("$EACH: {e}"));
+        return Value::Noval;
+    }
+    let srcpath = ia.get(1).cloned().unwrap_or(Value::Noval);
+    let origchildspec = ia.get(2).cloned().unwrap_or(Value::Noval);
+    let srcpath_str = srcpath.as_str().unwrap_or("").to_string();
+
+    let tkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+    let pathsize = path.len();
+    let nlen = nodes.len();
+    let target = if pathsize >= 2 {
+        nodes.get(pathsize - 2).cloned().unwrap_or(Value::Noval)
+    } else {
+        nodes.get(pathsize.saturating_sub(1)).cloned().unwrap_or(Value::Noval)
+    };
+    let target = if target.is_noval() {
+        nodes.get(pathsize.saturating_sub(1)).cloned().unwrap_or(Value::Noval)
+    } else {
+        target
+    };
+
+    let srcstore = get_prop(store, &Value::str(base.clone().unwrap_or_default()), store.clone());
+    let src_raw = get_path_inj(&srcstore, &srcpath, Some(inj));
+    let src: Value = if is_list(&src_raw) {
+        src_raw
+    } else if is_map(&src_raw) {
+        Value::list(
+            items_vec(&src_raw)
+                .into_iter()
+                .map(|(k, v)| {
+                    set_prop(
+                        v.clone(),
+                        &Value::str(S_BANNO),
+                        Value::map_of([(S_KEY.to_string(), Value::str(k))]),
+                    );
+                    v
+                })
+                .collect(),
+        )
+    } else {
+        return Value::Noval;
+    };
+    if src.is_nullish() {
+        return Value::Noval;
+    }
+
+    let keypath = get_prop(&origchildspec, &Value::str(S_BKEY), Value::Noval);
+    let childspec = del_prop(origchildspec.clone(), &Value::str(S_BKEY));
+    let child = get_prop(&childspec, &Value::str(S_BVAL), childspec.clone());
+
+    let resolve_key = |srckey: &str, srcnode: &Value| -> Value {
+        if keypath.is_noval() {
+            Value::str(srckey)
+        } else if let Value::Str(kp) = &keypath {
+            if kp.starts_with('`') {
+                let m = merge(
+                    &Value::list(vec![
+                        Value::empty_map(),
+                        store.clone(),
+                        Value::map_of([(S_DTOP.to_string(), srcnode.clone())]),
+                    ]),
+                    Some(1),
+                );
+                inject(Value::str(kp.clone()), &m, None)
+            } else {
+                get_path_inj(srcnode, &Value::str(kp.clone()), Some(inj))
+            }
+        } else {
+            Value::str(srckey)
+        }
+    };
+
+    let tval = Value::empty_map();
+    for (srckey, srcnode) in items_vec(&src) {
+        let k = resolve_key(&srckey, &srcnode);
+        let tchild = clone(&child);
+        set_prop(tval.clone(), &k, tchild.clone());
+        let anno = get_prop(&srcnode, &Value::str(S_BANNO), Value::Noval);
+        if anno.is_noval() {
+            del_prop(tchild, &Value::str(S_BANNO));
+        } else {
+            set_prop(tchild, &Value::str(S_BANNO), anno);
+        }
+    }
+
+    let mut rval = Value::empty_map();
+    if !is_empty(&tval) {
+        let tsrc = Value::empty_map();
+        for (i, (_, n)) in items_vec(&src).into_iter().enumerate() {
+            let kn = if keypath.is_noval() {
+                Value::Num(i as f64)
+            } else {
+                resolve_key("", &n)
+            };
+            set_prop(tsrc.clone(), &kn, n);
+        }
+        let tpath = slice_str_vec(&path, Some(-1), None);
+        let ckey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+        let mut dpath: Vec<String> = vec![S_DTOP.to_string()];
+        dpath.extend(srcpath_split(&srcpath_str));
+        dpath.push(format!("$:{ckey}"));
+        let mut tcur = Value::map_of([(ckey.clone(), tsrc)]);
+        if tpath.len() > 1 {
+            let pkey = path
+                .get(path.len().saturating_sub(3))
+                .cloned()
+                .unwrap_or_else(|| S_DTOP.to_string());
+            tcur = Value::map_of([(pkey.clone(), tcur)]);
+            dpath.push(format!("$:{pkey}"));
+        }
+        let tinj = Injection::child(inj, 0, Rc::new(RefCell::new(vec![ckey.clone()])));
+        {
+            let mut b = tinj.borrow_mut();
+            b.path = tpath;
+            b.nodes = if nlen >= 1 { nodes[..nlen - 1].to_vec() } else { Vec::new() };
+            b.parent = b.nodes.last().cloned().unwrap_or(Value::Noval);
+            b.val = tval.clone();
+            b.dpath = dpath;
+            b.dparent = tcur;
+        }
+        let _ = inject_inj(tval.clone(), store, &tinj);
+        rval = tinj.borrow().val.clone();
+    }
+
+    set_prop(target, &Value::str(tkey), rval);
+    Value::Noval
 }
 
 pub fn transform(
@@ -1125,16 +1650,16 @@ pub fn transform(
     store_base.insert("$KEY".to_string(), Value::func(transform_key));
     store_base.insert("$ANNO".to_string(), Value::func(transform_anno));
     store_base.insert("$MERGE".to_string(), Value::func(transform_merge));
-    store_base.insert("$EACH".to_string(), Value::func(transform_unsupported("EACH")));
-    store_base.insert("$PACK".to_string(), Value::func(transform_unsupported("PACK")));
-    store_base.insert("$REF".to_string(), Value::func(transform_unsupported("REF")));
+    store_base.insert("$EACH".to_string(), Value::func(transform_each));
+    store_base.insert("$PACK".to_string(), Value::func(transform_pack));
+    store_base.insert("$REF".to_string(), Value::func(transform_ref));
     store_base.insert(
         "$FORMAT".to_string(),
-        Value::func(transform_unsupported("FORMAT")),
+        Value::func(transform_format),
     );
     store_base.insert(
         "$APPLY".to_string(),
-        Value::func(transform_unsupported("APPLY")),
+        Value::func(transform_apply),
     );
 
     let store = merge(
@@ -1193,12 +1718,479 @@ fn civil_from_days(z: i64) -> (i64, i64, i64) {
     (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
+// ---- validate --------------------------------------------------------
+
+fn path_value(path: &[String]) -> Value {
+    Value::list(path.iter().cloned().map(Value::Str).collect())
+}
+
+fn invalid_type_msg(path: &[String], needtype: &str, vt: i64, v: &Value) -> String {
+    let vs = if v.is_nullish() {
+        "no value".to_string()
+    } else {
+        stringify(v, None, false)
+    };
+    let field_part = if path.len() > 1 {
+        format!("field {} to be ", pathify(&path_value(path), Some(1), None))
+    } else {
+        String::new()
+    };
+    let type_part = if !v.is_nullish() {
+        format!("{}{}", type_name(vt), S_VIZ)
+    } else {
+        String::new()
+    };
+    format!("Expected {field_part}{needtype}, but found {type_part}{vs}.")
+}
+
+fn validate_string(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (dparent, key, path) = {
+        let b = inj.borrow();
+        (b.dparent.clone(), b.key.clone(), b.path.clone())
+    };
+    let out = get_prop(&dparent, &Value::str(key), Value::Noval);
+    let t = typify(&out);
+    if t & (T_STRING as i64) == 0 {
+        errs_push(inj, invalid_type_msg(&path, "string", t, &out));
+        return Value::Noval;
+    }
+    if matches!(&out, Value::Str(s) if s.is_empty()) {
+        errs_push(
+            inj,
+            format!("Empty string at {}", pathify(&path_value(&path), Some(1), None)),
+        );
+        return Value::Noval;
+    }
+    out
+}
+
+fn validate_type(inj: &Inj, _v: &Value, r: &str, _store: &Value) -> Value {
+    let tname: String = r.chars().skip(1).collect::<String>().to_lowercase();
+    let typev: i64 = match TYPENAME.iter().position(|x| *x == tname) {
+        Some(idx) => 1i64 << (31 - idx as i64),
+        None => 0,
+    };
+    let (dparent, key, path) = {
+        let b = inj.borrow();
+        (b.dparent.clone(), b.key.clone(), b.path.clone())
+    };
+    let out = get_prop(&dparent, &Value::str(key), Value::Noval);
+    let t = typify(&out);
+    if t & typev == 0 {
+        errs_push(inj, invalid_type_msg(&path, &tname, t, &out));
+        return Value::Noval;
+    }
+    out
+}
+
+fn validate_any(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (dparent, key) = {
+        let b = inj.borrow();
+        (b.dparent.clone(), b.key.clone())
+    };
+    get_prop(&dparent, &Value::str(key), Value::Noval)
+}
+
+/// Render a list of tvals as `"a, b, c"`, lowering `` `$NAME` `` -> `name`.
+fn tvals_desc(tvals: &[Value]) -> String {
+    let joined = tvals
+        .iter()
+        .map(|v| stringify(v, None, false))
+        .collect::<Vec<_>>()
+        .join(", ");
+    R_TRANSFORM_NAME
+        .replace_all(&joined, |caps: &regex::Captures| caps[1].to_lowercase())
+        .to_string()
+}
+
+// Map / list `$CHILD`: apply a child template to every direct child.
+fn validate_child(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (mode, key, parent, path, dparent) = {
+        let b = inj.borrow();
+        (b.mode, b.key.clone(), b.parent.clone(), b.path.clone(), b.dparent.clone())
+    };
+
+    if mode == M_KEYPRE {
+        let childtm = get_prop(&parent, &Value::str(key), Value::Noval);
+        let pkey = path.get(path.len().saturating_sub(2)).cloned().unwrap_or_default();
+        let mut tval = get_prop(&dparent, &Value::str(pkey), Value::Noval);
+        if tval.is_noval() {
+            tval = Value::empty_map();
+        } else if !is_map(&tval) {
+            errs_push(
+                inj,
+                invalid_type_msg(&path[..path.len().saturating_sub(1)], S_object, typify(&tval), &tval),
+            );
+            return Value::Noval;
+        }
+        let ckeys = keysof_vec(&tval);
+        for ck in ckeys {
+            set_prop(parent.clone(), &Value::str(ck.clone()), clone(&childtm));
+            inj.borrow().keys.borrow_mut().push(ck);
+        }
+        Injection::setval(inj, Value::Noval, None);
+        return Value::Noval;
+    }
+
+    if mode == M_VAL {
+        if !is_list(&parent) {
+            errs_push(inj, "Invalid $CHILD as value".to_string());
+            return Value::Noval;
+        }
+        let childtm = get_prop(&parent, &Value::Num(1.0), Value::Noval);
+        if dparent.is_noval() {
+            slice(parent.clone(), Some(0), Some(0), true); // empty default
+            return Value::Noval;
+        }
+        if !is_list(&dparent) {
+            errs_push(
+                inj,
+                invalid_type_msg(&path[..path.len().saturating_sub(1)], S_list, typify(&dparent), &dparent),
+            );
+            let plen = parent.as_list().map(|l| l.borrow().len()).unwrap_or(0) as i64;
+            inj.borrow_mut().key_i = plen;
+            return dparent;
+        }
+        let dlen = dparent.as_list().map(|l| l.borrow().len()).unwrap_or(0);
+        for n in 0..dlen {
+            set_prop(parent.clone(), &Value::Num(n as f64), clone(&childtm));
+        }
+        slice(parent.clone(), Some(0), Some(dlen as i64), true);
+        inj.borrow_mut().key_i = 0;
+        return get_prop(&dparent, &Value::Num(0.0), Value::Noval);
+    }
+
+    Value::Noval
+}
+
+// `$ONE`: value must match exactly one of a list of alternative sub-specs.
+fn validate_one(inj: &Inj, _v: &Value, _r: &str, store: &Value) -> Value {
+    let (mode, parent, key_i) = {
+        let b = inj.borrow();
+        (b.mode, b.parent.clone(), b.key_i)
+    };
+    if mode != M_VAL {
+        return Value::Noval;
+    }
+    if !is_list(&parent) || key_i != 0 {
+        let path = inj.borrow().path.clone();
+        errs_push(
+            inj,
+            format!(
+                "The $ONE validator at field {} must be the first element of an array.",
+                pathify(&path_value(&path), Some(1), Some(1))
+            ),
+        );
+        return Value::Noval;
+    }
+    let keylen = inj.borrow().keys.borrow().len() as i64;
+    inj.borrow_mut().key_i = keylen;
+    let dparent = inj.borrow().dparent.clone();
+    Injection::setval(inj, dparent.clone(), Some(2));
+    {
+        let mut b = inj.borrow_mut();
+        let n = b.path.len();
+        b.path.truncate(n.saturating_sub(1));
+        b.key = b.path.last().cloned().unwrap_or_default();
+    }
+    let path_after = inj.borrow().path.clone();
+    let meta = inj.borrow().meta.clone();
+    let tvals: Vec<Value> = slice(parent.clone(), Some(1), None, false)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    if tvals.is_empty() {
+        errs_push(
+            inj,
+            format!(
+                "The $ONE validator at field {} must have at least one argument.",
+                pathify(&path_value(&path_after), Some(1), Some(1))
+            ),
+        );
+        return Value::Noval;
+    }
+    for tval in &tvals {
+        let terrs = Value::empty_list();
+        let mut vstore = match merge(&Value::list(vec![Value::empty_map(), store.clone()]), Some(1)) {
+            v @ Value::Map(_) => v,
+            _ => Value::empty_map(),
+        };
+        set_prop(vstore.clone(), &Value::str(S_DTOP), dparent.clone());
+        let _ = &mut vstore;
+        let vd = InjectDef {
+            extra: Some(vstore.clone()),
+            errs: Some(terrs.clone()),
+            meta: Some(meta.clone()),
+            ..Default::default()
+        };
+        let vcur = validate(&dparent, tval, Some(&vd)).unwrap_or(Value::Noval);
+        Injection::setval(inj, vcur, Some(-2)); // hmm: ancestor -2 -> handled below
+        let terrlen = terrs.as_list().map(|l| l.borrow().len()).unwrap_or(0);
+        if terrlen == 0 {
+            return Value::Noval;
+        }
+    }
+    let valdesc = tvals_desc(&tvals);
+    errs_push(
+        inj,
+        invalid_type_msg(
+            &path_after,
+            &format!("{}{}", if tvals.len() > 1 { "one of " } else { "" }, valdesc),
+            typify(&dparent),
+            &dparent,
+        ),
+    );
+    Value::Noval
+}
+
+// `$EXACT`: value must equal a literal exactly (no shape coercion).
+fn validate_exact(inj: &Inj, _v: &Value, _r: &str, _store: &Value) -> Value {
+    let (mode, parent, key, key_i) = {
+        let b = inj.borrow();
+        (b.mode, b.parent.clone(), b.key.clone(), b.key_i)
+    };
+    if mode != M_VAL {
+        del_prop(parent, &Value::str(key));
+        return Value::Noval;
+    }
+    if !is_list(&parent) || key_i != 0 {
+        let path = inj.borrow().path.clone();
+        errs_push(
+            inj,
+            format!(
+                "The $EXACT validator at field {} must be the first element of an array.",
+                pathify(&path_value(&path), Some(1), Some(1))
+            ),
+        );
+        return Value::Noval;
+    }
+    let keylen = inj.borrow().keys.borrow().len() as i64;
+    inj.borrow_mut().key_i = keylen;
+    let dparent = inj.borrow().dparent.clone();
+    Injection::setval(inj, dparent.clone(), Some(2));
+    {
+        let mut b = inj.borrow_mut();
+        let n = b.path.len();
+        b.path.truncate(n.saturating_sub(1));
+        b.key = b.path.last().cloned().unwrap_or_default();
+    }
+    let path_after = inj.borrow().path.clone();
+    let tvals: Vec<Value> = slice(parent.clone(), Some(1), None, false)
+        .as_list()
+        .map(|l| l.borrow().clone())
+        .unwrap_or_default();
+    if tvals.is_empty() {
+        errs_push(
+            inj,
+            format!(
+                "The $EXACT validator at field {} must have at least one argument.",
+                pathify(&path_value(&path_after), Some(1), Some(1))
+            ),
+        );
+        return Value::Noval;
+    }
+    let mut currentstr: Option<String> = None;
+    for tval in &tvals {
+        let mut exactmatch = tval == &dparent;
+        if !exactmatch && is_node(tval) {
+            let cs = currentstr.get_or_insert_with(|| stringify(&dparent, None, false)).clone();
+            exactmatch = stringify(tval, None, false) == cs;
+        }
+        if exactmatch {
+            return Value::Noval;
+        }
+    }
+    let valdesc = tvals_desc(&tvals);
+    let need = format!(
+        "{}exactly equal to {}{}",
+        if path_after.len() > 1 { "" } else { "value " },
+        if tvals.len() == 1 { "" } else { "one of " },
+        valdesc
+    );
+    errs_push(
+        inj,
+        invalid_type_msg(&path_after, &need, typify(&dparent), &dparent),
+    );
+    Value::Noval
+}
+
+/// `_validation` — the modify hook installed by `validate` (runs after the
+/// per-key special commands).
+fn validation_modify(pval: &Value, key: &Value, parent: &Value, inj: &Inj, _store: &Value) {
+    if pval.is_skip() {
+        return;
+    }
+    let (meta, dparent, path) = {
+        let b = inj.borrow();
+        (b.meta.clone(), b.dparent.clone(), b.path.clone())
+    };
+    let exact = matches!(
+        get_prop(&meta, &Value::str(S_BEXACT), Value::Bool(false)),
+        Value::Bool(true)
+    );
+    let cval = get_prop(&dparent, key, Value::Noval);
+    if !exact && cval.is_noval() {
+        return;
+    }
+    let ptype = typify(pval);
+    if ptype & (T_STRING as i64) != 0 {
+        if let Value::Str(s) = pval {
+            if s.contains(S_DS) {
+                return; // remaining special command — leave it
+            }
+        }
+    }
+    let ctype = typify(&cval);
+    if ptype != ctype && !pval.is_noval() {
+        errs_push(inj, invalid_type_msg(&path, &type_name(ptype), ctype, &cval));
+        return;
+    }
+
+    if is_map(&cval) {
+        if !is_map(pval) {
+            errs_push(inj, invalid_type_msg(&path, &type_name(ptype), ctype, &cval));
+            return;
+        }
+        let ckeys = keysof_vec(&cval);
+        let pkeys = keysof_vec(pval);
+        let open = matches!(
+            get_prop(pval, &Value::str(S_BOPEN), Value::Noval),
+            Value::Bool(true)
+        );
+        if !pkeys.is_empty() && !open {
+            let badkeys: Vec<String> = ckeys
+                .iter()
+                .filter(|ck| !has_key(pval, &Value::str((*ck).clone())))
+                .cloned()
+                .collect();
+            if !badkeys.is_empty() {
+                errs_push(
+                    inj,
+                    format!(
+                        "Unexpected keys at field {}{}{}",
+                        pathify(&path_value(&path), Some(1), None),
+                        S_VIZ,
+                        badkeys.join(", ")
+                    ),
+                );
+            }
+        } else {
+            merge(&Value::list(vec![pval.clone(), cval.clone()]), None);
+            if is_node(pval) {
+                del_prop(pval.clone(), &Value::str(S_BOPEN));
+            }
+        }
+    } else if is_list(&cval) {
+        if !is_list(pval) {
+            errs_push(inj, invalid_type_msg(&path, &type_name(ptype), ctype, &cval));
+        }
+    } else if exact {
+        if &cval != pval {
+            let pathmsg = if path.len() > 1 {
+                format!("at field {}{}", pathify(&path_value(&path), Some(1), None), S_VIZ)
+            } else {
+                String::new()
+            };
+            errs_push(
+                inj,
+                format!("Value {}{} should equal {}{}", pathmsg, js_string(&cval), js_string(pval), S_DT),
+            );
+        }
+    } else {
+        set_prop(parent.clone(), key, cval.clone());
+    }
+}
+
+/// `_validatehandler` — `getpath`/`_injectstr` handler installed by `validate`.
+fn validatehandler(inj: &Inj, val: &Value, r: &str, store: &Value) -> Value {
+    if let Some(caps) = R_META_PATH.captures(r) {
+        if &caps[2] == "=" {
+            Injection::setval(
+                inj,
+                Value::list(vec![Value::str(S_BEXACT), val.clone()]),
+                None,
+            );
+        } else {
+            Injection::setval(inj, val.clone(), None);
+        }
+        inj.borrow_mut().key_i = -1;
+        return Value::skip();
+    }
+    inject_handler(inj, val, r, store)
+}
+
 pub fn validate(
-    _data: &Value,
-    _spec: &Value,
-    _injdef: Option<&InjectDef>,
+    data: &Value,
+    spec: &Value,
+    injdef: Option<&InjectDef>,
 ) -> Result<Value, StructError> {
-    unimplemented!("validate: not yet ported — see rs/PLAN.md §10 and rs/NOTES.md")
+    let extra = injdef.and_then(|d| d.extra.clone());
+    let collect = injdef.map(|d| d.errs.is_some()).unwrap_or(false);
+    let errs = injdef
+        .and_then(|d| d.errs.clone())
+        .unwrap_or_else(Value::empty_list);
+
+    // build the validator store
+    let mut vmap: indexmap::IndexMap<String, Value> = indexmap::IndexMap::new();
+    for k in ["$DELETE", "$COPY", "$KEY", "$META", "$MERGE", "$EACH", "$PACK"] {
+        vmap.insert(k.to_string(), Value::Null);
+    }
+    vmap.insert("$STRING".to_string(), Value::func(validate_string));
+    for k in [
+        "$NUMBER", "$INTEGER", "$DECIMAL", "$BOOLEAN", "$NULL", "$NIL", "$MAP", "$LIST", "$FUNCTION",
+        "$INSTANCE",
+    ] {
+        vmap.insert(k.to_string(), Value::func(validate_type));
+    }
+    vmap.insert("$ANY".to_string(), Value::func(validate_any));
+    vmap.insert("$CHILD".to_string(), Value::func(validate_child));
+    vmap.insert("$ONE".to_string(), Value::func(validate_one));
+    vmap.insert("$EXACT".to_string(), Value::func(validate_exact));
+
+    let extra_or_empty = match &extra {
+        Some(e) => e.clone(),
+        None => Value::empty_map(),
+    };
+    let store = merge(
+        &Value::list(vec![
+            Value::map(vmap),
+            extra_or_empty,
+            Value::map_of([(S_DERRS.to_string(), errs.clone())]),
+        ]),
+        Some(1),
+    );
+
+    let meta = match injdef.and_then(|d| d.meta.clone()) {
+        Some(m) => m,
+        None => Value::empty_map(),
+    };
+    let exact_cur = get_prop(&meta, &Value::str(S_BEXACT), Value::Bool(false));
+    set_prop(meta.clone(), &Value::str(S_BEXACT), exact_cur);
+
+    let td = InjectDef {
+        meta: Some(meta),
+        extra: Some(store),
+        modify: Some(Rc::new(validation_modify) as Modify),
+        handler: Some(Rc::new(validatehandler) as NativeFn),
+        errs: Some(errs.clone()),
+        ..Default::default()
+    };
+
+    let out = transform(data, spec, Some(&td))
+        .unwrap_or(Value::Noval);
+
+    let errlen = errs.as_list().map(|l| l.borrow().len()).unwrap_or(0);
+    if errlen > 0 && !collect {
+        let msgs: Vec<String> = errs
+            .as_list()
+            .map(|l| l.borrow().iter().map(js_string).collect())
+            .unwrap_or_default();
+        return Err(StructError {
+            message: msgs.join(" | "),
+        });
+    }
+
+    Ok(out)
 }
 
 pub fn select(_children: &Value, _query: &Value) -> Value {

--- a/rs/src/mini.rs
+++ b/rs/src/mini.rs
@@ -240,9 +240,22 @@ pub fn pad(s: Value, padding: Option<i64>, padchar: Option<String>) -> String {
 // ---- node accessors ---------------------------------------------------
 
 /// `getelem(list, key, alt?)` — list lookup by integer key, negative counts
-/// from the end.
+/// from the end. If the element is absent and `alt` is a callable value, it
+/// is invoked (with the uniform `(inj, val, ref, store)` shape — a fresh
+/// throwaway injection, `Noval` value/store, empty ref) and its result used,
+/// mirroring the canonical `alt()` call.
 pub fn get_elem(val: &Value, key: &Value, alt: Value) -> Value {
-    get_elem_or_else(val, key, || alt)
+    let out = get_elem_or_else(val, key, || Value::Noval);
+    if !out.is_noval() {
+        return out;
+    }
+    match &alt {
+        Value::Func(f) => {
+            let inj = crate::major::Injection::from_def(None);
+            f(&inj, &Value::Noval, "", &Value::Noval)
+        }
+        _ => alt,
+    }
 }
 
 pub fn get_elem_or_else<F: FnOnce() -> Value>(val: &Value, key: &Value, alt: F) -> Value {

--- a/rs/src/mini.rs
+++ b/rs/src/mini.rs
@@ -149,7 +149,7 @@ pub fn slice(val: Value, start: Option<i64>, end: Option<i64>, mutate: bool) -> 
             s = 0;
         } else if let Some(mut ee) = end {
             if ee < 0 {
-                ee = vlen + ee;
+                ee += vlen;
                 if ee < 0 {
                     ee = 0;
                 }

--- a/rs/src/mini.rs
+++ b/rs/src/mini.rs
@@ -1,0 +1,952 @@
+// Copyright (c) 2025-2026 Voxgig Ltd. MIT LICENSE.
+// VERSION: @voxgig/struct 0.1.0
+//
+// Minor utilities — port of the predicate / accessor / string-and-JSON
+// helpers from StructUtility.ts. Names are idiomatic snake_case; see the
+// TS->Rust table in README.md.
+
+use indexmap::IndexMap;
+use regex::Regex;
+
+use crate::consts::*;
+use crate::value::{is_integer_f64, js_string, js_to_number, num_to_string, Value};
+
+const MIN_SAFE_INTEGER: i64 = -9007199254740991;
+const MAX_SAFE_INTEGER: i64 = 9007199254740991;
+
+// ---- type names / type codes ------------------------------------------
+
+/// `typename(t)` — human name for a type bit-flag.
+pub fn type_name(t: i64) -> String {
+    let idx = (t as u32).leading_zeros() as usize;
+    TYPENAME
+        .get(idx)
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| TYPENAME[0].to_string())
+}
+
+/// `typify(value)` — type bit-code for a value.
+pub fn typify(value: &Value) -> i64 {
+    match value {
+        Value::Noval => T_NOVAL as i64,
+        Value::Null => (T_SCALAR | T_NULL) as i64,
+        Value::Num(n) => {
+            if is_integer_f64(*n) {
+                (T_SCALAR | T_NUMBER | T_INTEGER) as i64
+            } else if n.is_nan() {
+                T_NOVAL as i64
+            } else {
+                (T_SCALAR | T_NUMBER | T_DECIMAL) as i64
+            }
+        }
+        Value::Str(_) => (T_SCALAR | T_STRING) as i64,
+        Value::Bool(_) => (T_SCALAR | T_BOOLEAN) as i64,
+        Value::Func(_) => (T_SCALAR | T_FUNCTION) as i64,
+        Value::List(_) => (T_NODE | T_LIST) as i64,
+        // Sentinels are `{ '`$SKIP`': true }` plain objects in TS.
+        Value::Map(_) | Value::Sentinel(_) => (T_NODE | T_MAP) as i64,
+    }
+}
+
+// ---- predicates -------------------------------------------------------
+
+pub fn get_def(val: Value, alt: Value) -> Value {
+    if val.is_noval() {
+        alt
+    } else {
+        val
+    }
+}
+
+pub fn is_node(val: &Value) -> bool {
+    matches!(val, Value::List(_) | Value::Map(_))
+}
+
+pub fn is_map(val: &Value) -> bool {
+    matches!(val, Value::Map(_))
+}
+
+pub fn is_list(val: &Value) -> bool {
+    matches!(val, Value::List(_))
+}
+
+pub fn is_key(key: &Value) -> bool {
+    match key {
+        Value::Str(s) => !s.is_empty(),
+        Value::Num(_) => true,
+        _ => false,
+    }
+}
+
+pub fn is_empty(val: &Value) -> bool {
+    match val {
+        Value::Noval | Value::Null => true,
+        Value::Str(s) => s.is_empty(),
+        Value::List(l) => l.borrow().is_empty(),
+        Value::Map(m) => m.borrow().is_empty(),
+        _ => false,
+    }
+}
+
+pub fn is_func(val: &Value) -> bool {
+    matches!(val, Value::Func(_))
+}
+
+/// `size(val)` — length for lists/strings, key count for maps, integer
+/// part for numbers, 1/0 for booleans, 0 otherwise.
+pub fn size(val: &Value) -> i64 {
+    match val {
+        Value::List(l) => l.borrow().len() as i64,
+        Value::Map(m) => m.borrow().len() as i64,
+        Value::Str(s) => s.encode_utf16().count() as i64,
+        Value::Num(n) => {
+            if n.is_finite() {
+                n.floor() as i64
+            } else {
+                0
+            }
+        }
+        Value::Bool(b) => {
+            if *b {
+                1
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+// ---- slice ------------------------------------------------------------
+
+/// `slice(val, start?, end?, mutate?)` — sub-section of a list, string, or
+/// bounded number. When `val` is a list and `mutate` is true, the list is
+/// truncated/shifted in place (and the same list value is returned).
+pub fn slice(val: Value, start: Option<i64>, end: Option<i64>, mutate: bool) -> Value {
+    if let Value::Num(n) = val {
+        let s = start.unwrap_or(MIN_SAFE_INTEGER);
+        let e = end.unwrap_or(MAX_SAFE_INTEGER) - 1;
+        let lo = n.max(s as f64);
+        let r = lo.min(e as f64);
+        return Value::Num(r);
+    }
+
+    let vlen = size(&val);
+
+    let mut start = start;
+    if end.is_some() && start.is_none() {
+        start = Some(0);
+    }
+
+    if let Some(mut s) = start {
+        let mut e: Option<i64>;
+        if s < 0 {
+            let mut ee = vlen + s;
+            if ee < 0 {
+                ee = 0;
+            }
+            e = Some(ee);
+            s = 0;
+        } else if let Some(mut ee) = end {
+            if ee < 0 {
+                ee = vlen + ee;
+                if ee < 0 {
+                    ee = 0;
+                }
+            } else if vlen < ee {
+                ee = vlen;
+            }
+            e = Some(ee);
+        } else {
+            e = Some(vlen);
+        }
+
+        if vlen < s {
+            s = vlen;
+        }
+
+        let e = e.take().unwrap_or(vlen);
+
+        if -1 < s && s <= e && e <= vlen {
+            match &val {
+                Value::List(l) => {
+                    if mutate {
+                        let mut lb = l.borrow_mut();
+                        let sub: Vec<Value> = lb[s as usize..e as usize].to_vec();
+                        *lb = sub;
+                        drop(lb);
+                        return val;
+                    } else {
+                        let lb = l.borrow();
+                        return Value::list(lb[s as usize..e as usize].to_vec());
+                    }
+                }
+                Value::Str(st) => {
+                    // substring by UTF-16 units to match JS .substring
+                    let units: Vec<u16> = st.encode_utf16().collect();
+                    let sub: Vec<u16> = units[s as usize..e as usize].to_vec();
+                    return Value::Str(String::from_utf16_lossy(&sub));
+                }
+                _ => {}
+            }
+        } else {
+            match &val {
+                Value::List(_) => return Value::empty_list(),
+                Value::Str(_) => return Value::Str(String::new()),
+                _ => {}
+            }
+        }
+    }
+
+    val
+}
+
+// ---- pad --------------------------------------------------------------
+
+pub fn pad(s: Value, padding: Option<i64>, padchar: Option<String>) -> String {
+    let mut s = match s {
+        Value::Str(s) => s,
+        other => stringify(&other, None, false),
+    };
+    let padding = padding.unwrap_or(44);
+    let padchar = {
+        let mut pc = padchar.unwrap_or_default();
+        pc.push(' ');
+        pc.chars().next().unwrap()
+    };
+    let cur = s.encode_utf16().count() as i64;
+    if padding > -1 {
+        if cur < padding {
+            for _ in 0..(padding - cur) {
+                s.push(padchar);
+            }
+        }
+        s
+    } else {
+        let target = -padding;
+        if cur < target {
+            let mut out = String::new();
+            for _ in 0..(target - cur) {
+                out.push(padchar);
+            }
+            out.push_str(&s);
+            out
+        } else {
+            s
+        }
+    }
+}
+
+// ---- node accessors ---------------------------------------------------
+
+/// `getelem(list, key, alt?)` — list lookup by integer key, negative counts
+/// from the end.
+pub fn get_elem(val: &Value, key: &Value, alt: Value) -> Value {
+    get_elem_or_else(val, key, || alt)
+}
+
+pub fn get_elem_or_else<F: FnOnce() -> Value>(val: &Value, key: &Value, alt: F) -> Value {
+    if val.is_noval() || key.is_noval() {
+        return alt();
+    }
+    let out = if let Value::List(l) = val {
+        let keystr = js_string(key);
+        if R_INTEGER_KEY.is_match(&keystr) {
+            match keystr.parse::<i64>() {
+                Ok(mut n) => {
+                    let lb = l.borrow();
+                    if n < 0 {
+                        n += lb.len() as i64;
+                    }
+                    if n >= 0 && (n as usize) < lb.len() {
+                        lb[n as usize].clone()
+                    } else {
+                        Value::Noval
+                    }
+                }
+                Err(_) => Value::Noval,
+            }
+        } else {
+            Value::Noval
+        }
+    } else {
+        Value::Noval
+    };
+    if out.is_noval() {
+        alt()
+    } else {
+        out
+    }
+}
+
+/// `getprop(node, key, alt?)` — safe property lookup on a map or list.
+pub fn get_prop(val: &Value, key: &Value, alt: Value) -> Value {
+    if val.is_noval() || key.is_noval() {
+        return alt;
+    }
+    let out = match val {
+        Value::List(l) => {
+            let lb = l.borrow();
+            // Array index: a non-negative integer (string or number).
+            let ks = js_string(key);
+            ks.parse::<usize>()
+                .ok()
+                .and_then(|i| lb.get(i).cloned())
+                .unwrap_or(Value::Noval)
+        }
+        Value::Map(m) => m.borrow().get(&js_string(key)).cloned().unwrap_or(Value::Noval),
+        Value::Sentinel(s) => {
+            if js_string(key) == s.tag {
+                Value::Bool(true)
+            } else {
+                Value::Noval
+            }
+        }
+        _ => Value::Noval,
+    };
+    if out.is_noval() {
+        alt
+    } else {
+        out
+    }
+}
+
+/// `strkey(key)` — coerce a key to its canonical string form (`""` if invalid).
+pub fn str_key(key: Value) -> String {
+    let t = typify(&key);
+    if t & (T_STRING as i64) != 0 {
+        return key.as_str().unwrap_or("").to_string();
+    }
+    if t & (T_BOOLEAN as i64) != 0 {
+        return String::new();
+    }
+    if t & (T_NUMBER as i64) != 0 {
+        if let Value::Num(n) = key {
+            return if n.fract() == 0.0 {
+                num_to_string(n)
+            } else {
+                num_to_string(n.floor())
+            };
+        }
+    }
+    String::new()
+}
+
+/// `keysof(node)` — sorted keys of a map, or list indices as strings.
+pub fn keysof_vec(val: &Value) -> Vec<String> {
+    match val {
+        Value::Map(m) => {
+            let mut ks: Vec<String> = m.borrow().keys().cloned().collect();
+            ks.sort();
+            ks
+        }
+        Value::List(l) => (0..l.borrow().len()).map(|i| i.to_string()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub fn keys_of(val: &Value) -> Value {
+    Value::list(keysof_vec(val).into_iter().map(Value::Str).collect())
+}
+
+pub fn has_key(val: &Value, key: &Value) -> bool {
+    !get_prop(val, key, Value::Noval).is_noval()
+}
+
+/// `items(node)` — `[key, value]` pairs (keys sorted, as strings).
+pub fn items_vec(val: &Value) -> Vec<(String, Value)> {
+    keysof_vec(val)
+        .into_iter()
+        .map(|k| {
+            let v = get_prop(val, &Value::str(k.clone()), Value::Noval);
+            (k, v)
+        })
+        .collect()
+}
+
+pub fn items(val: &Value) -> Value {
+    Value::list(
+        items_vec(val)
+            .into_iter()
+            .map(|(k, v)| Value::list(vec![Value::Str(k), v]))
+            .collect(),
+    )
+}
+
+// ---- flatten / filter -------------------------------------------------
+
+pub fn flatten(list: &Value, depth: Option<i64>) -> Value {
+    match list {
+        Value::List(l) => {
+            let d = depth.unwrap_or(1);
+            Value::list(flat_slice(&l.borrow(), d))
+        }
+        other => other.clone(),
+    }
+}
+
+fn flat_slice(v: &[Value], depth: i64) -> Vec<Value> {
+    let mut out = Vec::new();
+    for item in v {
+        match item {
+            Value::List(inner) if depth > 0 => out.extend(flat_slice(&inner.borrow(), depth - 1)),
+            other => out.push(other.clone()),
+        }
+    }
+    out
+}
+
+/// `flatten([a, b, [c]])` — internal helper taking a Vec directly. Default
+/// depth 1 (matches `flatten(...)` calls with no depth arg).
+#[allow(dead_code)]
+pub fn flatten_vals(v: Vec<Value>, depth: i64) -> Vec<Value> {
+    flat_slice(&v, depth)
+}
+
+pub fn filter_vals<F: Fn(&(String, Value)) -> bool>(val: &Value, check: F) -> Vec<Value> {
+    let all = items_vec(val);
+    let mut out = Vec::new();
+    for item in &all {
+        if check(item) {
+            out.push(item.1.clone());
+        }
+    }
+    out
+}
+
+pub fn filter<F: Fn(&(String, Value)) -> bool>(val: &Value, check: F) -> Value {
+    Value::list(filter_vals(val, check))
+}
+
+// ---- escaping / replace ----------------------------------------------
+
+/// `escre(s)` — escape regex metacharacters.
+pub fn esc_re(s: &Value) -> String {
+    let rs = coerce_for_replace(s);
+    R_ESCAPE_REGEXP
+        .replace_all(&rs, |caps: &regex::Captures| format!("\\{}", &caps[0]))
+        .to_string()
+}
+
+/// `escurl(s)` — `encodeURIComponent`.
+pub fn esc_url(s: &Value) -> String {
+    let s = match s {
+        Value::Str(s) => s.clone(),
+        Value::Noval | Value::Null => String::new(),
+        other => js_string(other),
+    };
+    let mut out = String::new();
+    for b in s.bytes() {
+        let c = b as char;
+        if c.is_ascii_alphanumeric() || "-_.!~*'()".contains(c) {
+            out.push(c);
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
+}
+
+/// The `replace`-helper's string coercion: undefined -> "", everything else
+/// via `stringify` (which returns a string unchanged).
+fn coerce_for_replace(s: &Value) -> String {
+    match s {
+        Value::Str(s) => s.clone(),
+        Value::Noval => String::new(),
+        other => stringify(other, None, false),
+    }
+}
+
+/// `replace(s, regex, literal-with-$1-$2)` — JS-style replace-all (the `g`
+/// behaviour). `$1`, `$2` etc. refer to capture groups; use `$$` for a
+/// literal `$`. (`$&` is not used by any call site; would be `${0}` here.)
+#[allow(dead_code)]
+pub fn replace_str(s: &Value, from: &Regex, to: &str) -> String {
+    let rs = coerce_for_replace(s);
+    from.replace_all(&rs, to).to_string()
+}
+
+// ---- join -------------------------------------------------------------
+
+pub fn join(arr: &Value, sep: Option<&str>, url: bool) -> String {
+    let sepdef = sep.unwrap_or(S_CM).to_string();
+    let sarr = size(arr);
+    let sepre: Option<String> = if sepdef.encode_utf16().count() == 1 {
+        Some(esc_re(&Value::str(sepdef.clone())))
+    } else {
+        None
+    };
+
+    // filter to string non-empty entries
+    let str_entries: Vec<Value> = filter_vals(arr, |n| {
+        matches!(&n.1, Value::Str(s) if !s.is_empty())
+    });
+
+    let processed: Vec<String> = items_vec(&Value::list(str_entries))
+        .into_iter()
+        .map(|(idx_str, v)| {
+            let i = idx_str.parse::<i64>().unwrap_or(0);
+            let mut s = v.as_str().unwrap_or("").to_string();
+            if let Some(sre) = &sepre {
+                if !sre.is_empty() {
+                    if url && i == 0 {
+                        s = re_replace_first(&format!("{sre}+$"), &s, "");
+                        return s;
+                    }
+                    if i > 0 {
+                        s = re_replace_first(&format!("^{sre}+"), &s, "");
+                    }
+                    if i < sarr - 1 || !url {
+                        s = re_replace_first(&format!("{sre}+$"), &s, "");
+                    }
+                    let pat = format!("([^{sre}]){sre}+([^{sre}])");
+                    let repl = format!("${{1}}{sepdef}${{2}}");
+                    s = re_replace_first(&pat, &s, &repl);
+                }
+            }
+            s
+        })
+        .collect();
+
+    processed
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(&sepdef)
+}
+
+/// `join` over an already-built `Vec<Value>`.
+pub fn join_vals(arr: &[Value], sep: Option<&str>, url: bool) -> String {
+    join(&Value::list(arr.to_vec()), sep, url)
+}
+
+fn re_replace_first(pat: &str, s: &str, repl: &str) -> String {
+    match Regex::new(pat) {
+        Ok(re) => re.replace(s, repl).to_string(),
+        Err(_) => s.to_string(),
+    }
+}
+
+// ---- jsonify / stringify ---------------------------------------------
+
+pub struct JsonFlags {
+    pub indent: usize,
+    pub offset: usize,
+}
+
+impl Default for JsonFlags {
+    fn default() -> Self {
+        JsonFlags { indent: 2, offset: 0 }
+    }
+}
+
+/// `jsonify(val, flags?)` — strict JSON serialisation, default 2-space indent.
+pub fn jsonify(val: &Value, flags: Option<&JsonFlags>) -> String {
+    let def = JsonFlags::default();
+    let flags = flags.unwrap_or(&def);
+    if val.is_nullish() {
+        return S_null.to_string();
+    }
+    let mut s = match json_encode(val, flags.indent, 0) {
+        Some(s) => s,
+        None => return S_null.to_string(),
+    };
+    if flags.offset > 0 {
+        // Left-offset every line but the first by `offset` spaces.
+        let lines: Vec<&str> = s.split('\n').collect();
+        let mut out = String::from("{\n");
+        let mut parts: Vec<String> = Vec::new();
+        for line in lines.iter().skip(1) {
+            parts.push(pad(
+                Value::str(*line),
+                Some(0 - flags.offset as i64 - line.encode_utf16().count() as i64),
+                None,
+            ));
+        }
+        out.push_str(&parts.join("\n"));
+        s = out;
+    }
+    s
+}
+
+fn json_encode(val: &Value, indent: usize, level: usize) -> Option<String> {
+    match val {
+        Value::Noval => None,
+        Value::Func(_) => None,
+        Value::Null => Some("null".to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Num(n) => {
+            if n.is_finite() {
+                Some(num_to_string(*n))
+            } else {
+                Some("null".to_string())
+            }
+        }
+        Value::Str(s) => Some(json_quote(s)),
+        Value::Sentinel(_) => {
+            // a `{ '`$SKIP`': true }` map
+            let mut m = IndexMap::new();
+            let tag = match val {
+                Value::Sentinel(s) => s.tag.to_string(),
+                _ => unreachable!(),
+            };
+            m.insert(tag, Value::Bool(true));
+            json_encode(&Value::map(m), indent, level)
+        }
+        Value::List(l) => {
+            let lb = l.borrow();
+            if lb.is_empty() {
+                return Some("[]".to_string());
+            }
+            let inner_pad = " ".repeat(indent * (level + 1));
+            let outer_pad = " ".repeat(indent * level);
+            let nl = if indent > 0 { "\n" } else { "" };
+            let sep = if indent > 0 { ",\n" } else { "," };
+            let items: Vec<String> = lb
+                .iter()
+                .map(|v| {
+                    let enc = json_encode(v, indent, level + 1).unwrap_or_else(|| "null".to_string());
+                    if indent > 0 {
+                        format!("{inner_pad}{enc}")
+                    } else {
+                        enc
+                    }
+                })
+                .collect();
+            Some(format!("[{nl}{}{nl}{outer_pad}]", items.join(sep)))
+        }
+        Value::Map(m) => {
+            let mb = m.borrow();
+            // drop undefined / function-valued keys
+            let entries: Vec<(&String, &Value)> = mb
+                .iter()
+                .filter(|(_, v)| !matches!(v, Value::Noval | Value::Func(_)))
+                .collect();
+            if entries.is_empty() {
+                return Some("{}".to_string());
+            }
+            let inner_pad = " ".repeat(indent * (level + 1));
+            let outer_pad = " ".repeat(indent * level);
+            let nl = if indent > 0 { "\n" } else { "" };
+            let colon = if indent > 0 { ": " } else { ":" };
+            let sep = if indent > 0 { ",\n" } else { "," };
+            let items: Vec<String> = entries
+                .iter()
+                .map(|(k, v)| {
+                    let enc = json_encode(v, indent, level + 1).unwrap_or_else(|| "null".to_string());
+                    if indent > 0 {
+                        format!("{inner_pad}{}{colon}{enc}", json_quote(k))
+                    } else {
+                        format!("{}{colon}{enc}", json_quote(k))
+                    }
+                })
+                .collect();
+            Some(format!("{{{nl}{}{nl}{outer_pad}}}", items.join(sep)))
+        }
+    }
+}
+
+fn json_quote(s: &str) -> String {
+    let mut out = String::from("\"");
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// `stringify(val, maxlen?, pretty?)` — compact, human-friendly string form.
+pub fn stringify(val: &Value, maxlen: Option<i64>, pretty: bool) -> String {
+    let mut valstr;
+    if val.is_noval() {
+        return if pretty { "<>".to_string() } else { String::new() };
+    }
+    if let Value::Str(s) = val {
+        valstr = s.clone();
+    } else {
+        match human_json(val) {
+            Some(s) => {
+                // remove all double-quotes (a deliberate quirk)
+                valstr = s.replace('"', "");
+            }
+            None => return "__STRINGIFY_FAILED__".to_string(),
+        }
+    }
+
+    if let Some(m) = maxlen {
+        if m >= 0 {
+            let m = m as usize;
+            let chars: Vec<char> = valstr.chars().collect();
+            if chars.len() > m {
+                let keep = m.saturating_sub(3);
+                let head: String = chars.iter().take(keep).collect();
+                valstr = format!("{head}...");
+            }
+        }
+    }
+
+    if pretty {
+        return ansi_colour(&valstr);
+    }
+
+    valstr
+}
+
+/// Compact JSON with object keys sorted (used by `stringify`). Functions and
+/// `undefined` map values are dropped. Cycles are not detected -> caller maps
+/// the failure to `__STRINGIFY_FAILED__` only if recursion overflows (which
+/// would actually panic); we approximate with a depth guard.
+fn human_json(val: &Value) -> Option<String> {
+    human_json_depth(val, 0)
+}
+
+fn human_json_depth(val: &Value, depth: usize) -> Option<String> {
+    if depth > 1_000 {
+        return None;
+    }
+    match val {
+        Value::Noval => None,
+        Value::Func(_) => None,
+        Value::Null => Some("null".to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Num(n) => Some(if n.is_finite() {
+            num_to_string(*n)
+        } else {
+            "null".to_string()
+        }),
+        Value::Str(s) => Some(json_quote(s)),
+        Value::Sentinel(s) => Some(format!("{{\"{}\":true}}", s.tag)),
+        Value::List(l) => {
+            let lb = l.borrow();
+            let parts: Vec<String> = lb
+                .iter()
+                .map(|v| human_json_depth(v, depth + 1).unwrap_or_else(|| "null".to_string()))
+                .collect();
+            Some(format!("[{}]", parts.join(",")))
+        }
+        Value::Map(m) => {
+            let mb = m.borrow();
+            let mut keys: Vec<&String> = mb
+                .iter()
+                .filter(|(_, v)| !matches!(v, Value::Noval | Value::Func(_)))
+                .map(|(k, _)| k)
+                .collect();
+            keys.sort();
+            let parts: Vec<String> = keys
+                .iter()
+                .map(|k| {
+                    let v = mb.get(*k).unwrap();
+                    format!(
+                        "{}:{}",
+                        json_quote(k),
+                        human_json_depth(v, depth + 1).unwrap_or_else(|| "null".to_string())
+                    )
+                })
+                .collect();
+            Some(format!("{{{}}}", parts.join(",")))
+        }
+    }
+}
+
+fn ansi_colour(valstr: &str) -> String {
+    let colours = [
+        81, 118, 213, 39, 208, 201, 45, 190, 129, 51, 160, 121, 226, 33, 207, 69,
+    ];
+    let c: Vec<String> = colours.iter().map(|n| format!("\x1b[38;5;{n}m")).collect();
+    let r = "\x1b[0m";
+    let mut d: i64 = 0;
+    let mut o = c[0].clone();
+    let mut t = o.clone();
+    for ch in valstr.chars() {
+        if ch == '{' || ch == '[' {
+            d += 1;
+            o = c[(d as usize) % c.len()].clone();
+            t.push_str(&o);
+            t.push(ch);
+        } else if ch == '}' || ch == ']' {
+            t.push_str(&o);
+            t.push(ch);
+            d -= 1;
+            o = c[(d.rem_euclid(c.len() as i64)) as usize].clone();
+        } else {
+            t.push_str(&o);
+            t.push(ch);
+        }
+    }
+    t.push_str(r);
+    t
+}
+
+// ---- pathify ----------------------------------------------------------
+
+pub fn pathify(val: &Value, startin: Option<i64>, endin: Option<i64>) -> String {
+    let path: Option<Vec<Value>> = match val {
+        Value::List(l) => Some(l.borrow().clone()),
+        Value::Str(_) | Value::Num(_) => Some(vec![val.clone()]),
+        _ => None,
+    };
+    let start = match startin {
+        None => 0,
+        Some(s) if -1 < s => s,
+        _ => 0,
+    };
+    let end = match endin {
+        None => 0,
+        Some(e) if -1 < e => e,
+        _ => 0,
+    };
+
+    let mut pathstr: Option<String> = None;
+    if let Some(path) = &path {
+        if start >= 0 {
+            let plen = path.len() as i64;
+            let sliced = slice(Value::list(path.clone()), Some(start), Some(plen - end), false);
+            let sv: Vec<Value> = sliced
+                .as_list()
+                .map(|l| l.borrow().clone())
+                .unwrap_or_default();
+            if sv.is_empty() {
+                pathstr = Some("<root>".to_string());
+            } else {
+                let filtered = filter_vals(&Value::list(sv), |n| is_key(&n.1));
+                let mapped: Vec<Value> = filtered
+                    .iter()
+                    .map(|p| match p {
+                        Value::Num(n) => Value::str(num_to_string(n.floor())),
+                        _ => Value::str(p.as_str().unwrap_or("").replace('.', "")),
+                    })
+                    .collect();
+                pathstr = Some(join_vals(&mapped, Some("."), false));
+            }
+        }
+    }
+
+    pathstr.unwrap_or_else(|| {
+        let tail = if val.is_noval() {
+            String::new()
+        } else {
+            format!("{}{}", S_CN, stringify(val, Some(47), false))
+        };
+        format!("<unknown-path{tail}>")
+    })
+}
+
+// ---- clone ------------------------------------------------------------
+
+/// `clone(val)` — deep copy. Functions and sentinels are copied (not cloned).
+pub fn clone(val: &Value) -> Value {
+    match val {
+        Value::Noval => Value::Noval,
+        Value::Null => Value::Null,
+        Value::Bool(b) => Value::Bool(*b),
+        Value::Num(n) => Value::Num(*n),
+        Value::Str(s) => Value::Str(s.clone()),
+        Value::List(l) => Value::list(l.borrow().iter().map(clone).collect()),
+        Value::Map(m) => {
+            let mut nm = IndexMap::new();
+            for (k, v) in m.borrow().iter() {
+                nm.insert(k.clone(), clone(v));
+            }
+            Value::map(nm)
+        }
+        Value::Func(f) => Value::Func(f.clone()),
+        Value::Sentinel(s) => Value::Sentinel(s),
+    }
+}
+
+// ---- delprop / setprop -----------------------------------------------
+
+pub fn del_prop(parent: Value, key: &Value) -> Value {
+    if !is_key(key) {
+        return parent;
+    }
+    match &parent {
+        Value::Map(m) => {
+            let k = str_key(key.clone());
+            m.borrow_mut().shift_remove(&k);
+        }
+        Value::List(l) => {
+            let ki = js_to_number(key);
+            if ki.is_nan() {
+                return parent;
+            }
+            let ki = ki.floor() as i64;
+            let mut lb = l.borrow_mut();
+            if ki >= 0 && (ki as usize) < lb.len() {
+                lb.remove(ki as usize);
+            }
+        }
+        _ => {}
+    }
+    parent
+}
+
+pub fn set_prop(parent: Value, key: &Value, val: Value) -> Value {
+    if !is_key(key) {
+        return parent;
+    }
+    match &parent {
+        Value::Map(m) => {
+            let k = js_string(key);
+            m.borrow_mut().insert(k, val);
+        }
+        Value::List(l) => {
+            let ki = js_to_number(key);
+            if ki.is_nan() {
+                return parent;
+            }
+            let ki = ki.floor() as i64;
+            let mut lb = l.borrow_mut();
+            if ki >= 0 {
+                let len = lb.len() as i64;
+                let idx = ki.min(len).max(0) as usize;
+                if idx < lb.len() {
+                    lb[idx] = val;
+                } else {
+                    lb.push(val);
+                }
+            } else {
+                lb.insert(0, val);
+            }
+        }
+        _ => {}
+    }
+    parent
+}
+
+// ---- builders ---------------------------------------------------------
+
+pub fn jm(kv: &[Value]) -> Value {
+    let mut o = IndexMap::new();
+    let n = kv.len();
+    let mut i = 0;
+    while i < n {
+        let k = match kv.get(i) {
+            Some(Value::Str(s)) => s.clone(),
+            Some(other) => stringify(other, None, false),
+            None => format!("$KEY{i}"),
+        };
+        let v = kv.get(i + 1).cloned().unwrap_or(Value::Null);
+        o.insert(k, v);
+        i += 2;
+    }
+    Value::map(o)
+}
+
+pub fn jt(v: &[Value]) -> Value {
+    Value::list(
+        v.iter()
+            .map(|x| if x.is_noval() { Value::Null } else { x.clone() })
+            .collect(),
+    )
+}

--- a/rs/src/value.rs
+++ b/rs/src/value.rs
@@ -1,0 +1,369 @@
+// Copyright (c) 2025-2026 Voxgig Ltd. MIT LICENSE.
+// VERSION: @voxgig/struct 0.1.0
+//
+// The in-memory JSON-shaped value type for the Rust port. See rs/PLAN.md.
+//
+// - `Noval` is the TS `undefined` — property absent. NOT a scalar.
+// - `Null` is JSON null — a real value, distinct from `Noval`.
+// - Lists and maps are `Rc<RefCell<...>>`: reference-stable, mutated in place.
+// - `IndexMap` preserves insertion order (the inject machinery needs it).
+// - `Func` carries callables that live inside the data (transform commands, etc.).
+// - `Sentinel` (SKIP / DELETE) is compared by pointer identity.
+
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
+use indexmap::IndexMap;
+
+use crate::major::Inj;
+
+pub type VList = Rc<RefCell<Vec<Value>>>;
+pub type VMap = Rc<RefCell<IndexMap<String, Value>>>;
+
+/// Injector-shaped native function: `(inj, val, ref, store) -> any`.
+/// Thunks (e.g. `$WHEN`) just ignore the arguments. Takes the injection by
+/// `&Inj` (the `Rc<RefCell<…>>`) so injectors can re-borrow it as needed.
+pub type NativeFn = Rc<dyn Fn(&Inj, &Value, &str, &Value) -> Value>;
+
+/// `Modify` hook: mutates `parent[key]` (or `inj`), returns nothing.
+pub type ModifyFn = Rc<dyn Fn(&Value, &Value, &Value, &Inj, &Value)>;
+
+/// Identity-only marker for SKIP / DELETE.
+pub struct Sentinel {
+    pub tag: &'static str,
+}
+
+pub static SKIP: Sentinel = Sentinel { tag: "`$SKIP`" };
+pub static DELETE: Sentinel = Sentinel { tag: "`$DELETE`" };
+
+#[derive(Clone)]
+pub enum Value {
+    Noval,
+    Null,
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    List(VList),
+    Map(VMap),
+    Func(NativeFn),
+    Sentinel(&'static Sentinel),
+}
+
+impl Value {
+    // ---- constructors --------------------------------------------------
+
+    pub fn list(items: Vec<Value>) -> Value {
+        Value::List(Rc::new(RefCell::new(items)))
+    }
+
+    pub fn empty_list() -> Value {
+        Value::list(Vec::new())
+    }
+
+    pub fn map(entries: IndexMap<String, Value>) -> Value {
+        Value::Map(Rc::new(RefCell::new(entries)))
+    }
+
+    pub fn empty_map() -> Value {
+        Value::map(IndexMap::new())
+    }
+
+    pub fn map_of<I: IntoIterator<Item = (String, Value)>>(pairs: I) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert(k, v);
+        }
+        Value::map(m)
+    }
+
+    pub fn func<F>(f: F) -> Value
+    where
+        F: Fn(&Inj, &Value, &str, &Value) -> Value + 'static,
+    {
+        Value::Func(Rc::new(f))
+    }
+
+    pub fn str<S: Into<String>>(s: S) -> Value {
+        Value::Str(s.into())
+    }
+
+    pub fn skip() -> Value {
+        Value::Sentinel(&SKIP)
+    }
+
+    pub fn delete() -> Value {
+        Value::Sentinel(&DELETE)
+    }
+
+    // ---- predicates / accessors ---------------------------------------
+
+    pub fn is_noval(&self) -> bool {
+        matches!(self, Value::Noval)
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    /// JS `null == val` — true for both `undefined` and JSON `null`.
+    pub fn is_nullish(&self) -> bool {
+        matches!(self, Value::Noval | Value::Null)
+    }
+
+    pub fn is_skip(&self) -> bool {
+        matches!(self, Value::Sentinel(s) if std::ptr::eq(*s, &SKIP))
+    }
+
+    pub fn is_delete(&self) -> bool {
+        matches!(self, Value::Sentinel(s) if std::ptr::eq(*s, &DELETE))
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::Str(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    pub fn as_num(&self) -> Option<f64> {
+        match self {
+            Value::Num(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    pub fn as_list(&self) -> Option<&VList> {
+        match self {
+            Value::List(l) => Some(l),
+            _ => None,
+        }
+    }
+
+    pub fn as_map(&self) -> Option<&VMap> {
+        match self {
+            Value::Map(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    pub fn as_func(&self) -> Option<&NativeFn> {
+        match self {
+            Value::Func(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Truthy in the JS sense (used rarely; mostly for predicate returns).
+    pub fn truthy(&self) -> bool {
+        match self {
+            Value::Noval | Value::Null => false,
+            Value::Bool(b) => *b,
+            Value::Num(n) => *n != 0.0 && !n.is_nan(),
+            Value::Str(s) => !s.is_empty(),
+            _ => true,
+        }
+    }
+}
+
+// Deep, order-independent (for maps) equality — matches `deepStrictEqual`
+// semantics used by the corpus runner and the JSON-string fallback used by
+// `validate_EXACT`. Functions are never equal (pointer-eq would also do).
+impl PartialEq for Value {
+    fn eq(&self, other: &Value) -> bool {
+        match (self, other) {
+            (Value::Noval, Value::Noval) => true,
+            (Value::Null, Value::Null) => true,
+            (Value::Bool(a), Value::Bool(b)) => a == b,
+            (Value::Num(a), Value::Num(b)) => a == b,
+            (Value::Str(a), Value::Str(b)) => a == b,
+            (Value::Sentinel(a), Value::Sentinel(b)) => std::ptr::eq(*a, *b),
+            (Value::List(a), Value::List(b)) => {
+                if Rc::ptr_eq(a, b) {
+                    return true;
+                }
+                let a = a.borrow();
+                let b = b.borrow();
+                a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x == y)
+            }
+            (Value::Map(a), Value::Map(b)) => {
+                if Rc::ptr_eq(a, b) {
+                    return true;
+                }
+                let a = a.borrow();
+                let b = b.borrow();
+                a.len() == b.len()
+                    && a.iter().all(|(k, v)| b.get(k).map(|w| v == w).unwrap_or(false))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Noval => write!(f, "Noval"),
+            Value::Null => write!(f, "Null"),
+            Value::Bool(b) => write!(f, "Bool({b})"),
+            Value::Num(n) => write!(f, "Num({n})"),
+            Value::Str(s) => write!(f, "Str({s:?})"),
+            Value::List(l) => write!(f, "List({:?})", l.borrow()),
+            Value::Map(m) => write!(f, "Map({:?})", m.borrow()),
+            Value::Func(_) => write!(f, "Func(..)"),
+            Value::Sentinel(s) => write!(f, "Sentinel({})", s.tag),
+        }
+    }
+}
+
+// Convenient `From` impls for building values in tests / the runner.
+impl From<bool> for Value {
+    fn from(b: bool) -> Value {
+        Value::Bool(b)
+    }
+}
+impl From<i64> for Value {
+    fn from(n: i64) -> Value {
+        Value::Num(n as f64)
+    }
+}
+impl From<i32> for Value {
+    fn from(n: i32) -> Value {
+        Value::Num(n as f64)
+    }
+}
+impl From<usize> for Value {
+    fn from(n: usize) -> Value {
+        Value::Num(n as f64)
+    }
+}
+impl From<f64> for Value {
+    fn from(n: f64) -> Value {
+        Value::Num(n)
+    }
+}
+impl From<&str> for Value {
+    fn from(s: &str) -> Value {
+        Value::Str(s.to_string())
+    }
+}
+impl From<String> for Value {
+    fn from(s: String) -> Value {
+        Value::Str(s)
+    }
+}
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    fn from(v: Vec<T>) -> Value {
+        Value::list(v.into_iter().map(Into::into).collect())
+    }
+}
+
+// ---- JS numeric / string coercions ------------------------------------
+//
+// The canonical leans on JS coercions with no Rust stdlib equivalent.
+// Implemented faithfully for the cases the corpus exercises.
+
+/// `Number.isInteger(v)` — note `Number.isInteger(2.0) === true`.
+pub fn is_integer_f64(v: f64) -> bool {
+    v.is_finite() && v.fract() == 0.0
+}
+
+/// `String(v)` / `"" + v` for the value kinds that get stringified as keys.
+pub fn js_string(v: &Value) -> String {
+    match v {
+        Value::Noval => "undefined".to_string(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Num(n) => num_to_string(*n),
+        Value::Str(s) => s.clone(),
+        // JS `String([1,2])` => "1,2"; `String({})` => "[object Object]".
+        Value::List(l) => l
+            .borrow()
+            .iter()
+            .map(|x| match x {
+                Value::Noval | Value::Null => String::new(),
+                _ => js_string(x),
+            })
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Map(_) => "[object Object]".to_string(),
+        Value::Func(_) => "function".to_string(),
+        Value::Sentinel(s) => s.tag.to_string(),
+    }
+}
+
+/// JS number -> string. Differs from JS only for very large / very small
+/// magnitudes where JS switches to exponent notation (documented gap).
+pub fn num_to_string(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    if n.is_infinite() {
+        return if n > 0.0 { "Infinity" } else { "-Infinity" }.to_string();
+    }
+    if n == 0.0 {
+        return "0".to_string();
+    }
+    if n.fract() == 0.0 && n.abs() < 1e21 {
+        // Integer-valued: no decimal point, no exponent.
+        return format!("{}", n as i128);
+    }
+    let s = format!("{n}");
+    s
+}
+
+/// JS unary `+x` / `Number(x)` (ToNumber). Returns NaN on failure.
+pub fn js_to_number(v: &Value) -> f64 {
+    match v {
+        Value::Noval => f64::NAN,
+        Value::Null => 0.0,
+        Value::Bool(b) => {
+            if *b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        Value::Num(n) => *n,
+        Value::Str(s) => js_string_to_number(s),
+        Value::List(l) => {
+            let b = l.borrow();
+            match b.len() {
+                0 => 0.0,
+                1 => js_to_number(&b[0]),
+                _ => f64::NAN,
+            }
+        }
+        _ => f64::NAN,
+    }
+}
+
+/// `Number("...")` for a string: trims, accepts decimal/hex/empty.
+pub fn js_string_to_number(s: &str) -> f64 {
+    let t = s.trim();
+    if t.is_empty() {
+        return 0.0;
+    }
+    if let Some(hex) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
+        return i64::from_str_radix(hex, 16).map(|n| n as f64).unwrap_or(f64::NAN);
+    }
+    t.parse::<f64>().unwrap_or(f64::NAN)
+}
+
+/// JS `n | 0` (ToInt32): truncate toward zero, wrap mod 2^32, signed.
+pub fn js_to_int32(n: f64) -> i32 {
+    if !n.is_finite() {
+        return 0;
+    }
+    let trunc = n.trunc();
+    // wrap into u32 then reinterpret as i32
+    let m = trunc.rem_euclid(4294967296.0);
+    m as u32 as i32
+}

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -902,6 +902,57 @@ fn corpus() {
     eprintln!("corpus: {} checks passed", run.passed);
 }
 
+// Function values embedded in data: `get_elem` with a callable `alt`, and
+// `$APPLY` / a user `$FORMAT` formatter — see rs/README.md "Function values".
+#[test]
+fn function_values() {
+    // get_elem: absent element + callable alt -> alt is invoked
+    assert_eq!(
+        get_elem(
+            &Value::empty_list(),
+            &Value::Num(1.0),
+            Value::func(|_i: &Inj, _v: &Value, _r: &str, _s: &Value| Value::Num(2.0)),
+        ),
+        Value::Num(2.0)
+    );
+    // present element wins over the callable alt
+    assert_eq!(
+        get_elem(
+            &Value::list(vec![Value::Num(9.0)]),
+            &Value::Num(0.0),
+            Value::func(|_i: &Inj, _v: &Value, _r: &str, _s: &Value| Value::Num(2.0)),
+        ),
+        Value::Num(9.0)
+    );
+
+    // $APPLY: ['`$APPLY`', applyFn, child] — applyFn called with (inj, val=resolved, "", store)
+    let spec = Value::list(vec![
+        Value::str("`$APPLY`"),
+        Value::func(|_i: &Inj, v: &Value, _r: &str, _s: &Value| {
+            // v is the resolved child; double a number
+            match v {
+                Value::Num(n) => Value::Num(n * 2.0),
+                other => other.clone(),
+            }
+        }),
+        Value::Num(21.0),
+    ]);
+    let out = transform(&Value::empty_map(), &spec, None).unwrap();
+    assert_eq!(out, Value::Num(42.0));
+
+    // $FORMAT with a user function: applied per node, receives (inj, val, "", store)
+    let spec = Value::list(vec![
+        Value::str("`$FORMAT`"),
+        Value::func(|_i: &Inj, v: &Value, _r: &str, _s: &Value| match v {
+            Value::Str(s) => Value::str(format!("[{s}]")),
+            other => other.clone(),
+        }),
+        Value::str("hi"),
+    ]);
+    let out = transform(&Value::empty_map(), &spec, None).unwrap();
+    assert_eq!(out, Value::str("[hi]"));
+}
+
 // quiet unused-import warnings for the staged bits
 #[allow(dead_code)]
 fn _unused() {

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -533,11 +533,130 @@ fn corpus() {
         };
         walk(vin, Some(&mut walkpath), None, None)
     });
+    // walk.log — three runs (after-only / before-only / both) of a logging callback.
+    {
+        let log_spec = vget_path(&s, &["walk", "log"]);
+        let input = clone(&vget(&log_spec, "in"));
+        let want = vget(&log_spec, "out");
+        let mk_log = |inp: &Value, before: bool, after: bool| -> Value {
+            let lines = Rc::new(RefCell::new(Vec::<Value>::new()));
+            let lc = lines.clone();
+            let mut cb = move |k: &Value, v: &Value, p: &Value, path: &[String]| -> Value {
+                lc.borrow_mut().push(Value::str(format!(
+                    "k={}, v={}, p={}, t={}",
+                    stringify(k, None, false),
+                    stringify(v, None, false),
+                    stringify(p, None, false),
+                    pathify(&Value::list(path.iter().cloned().map(Value::Str).collect()), None, None),
+                )));
+                v.clone()
+            };
+            let mut cb2 = {
+                let lc = lines.clone();
+                move |k: &Value, v: &Value, p: &Value, path: &[String]| -> Value {
+                    lc.borrow_mut().push(Value::str(format!(
+                        "k={}, v={}, p={}, t={}",
+                        stringify(k, None, false),
+                        stringify(v, None, false),
+                        stringify(p, None, false),
+                        pathify(&Value::list(path.iter().cloned().map(Value::Str).collect()), None, None),
+                    )));
+                    v.clone()
+                }
+            };
+            let _ = walk(
+                clone(inp),
+                if before { Some(&mut cb) } else { None },
+                if after { Some(&mut cb2) } else { None },
+                None,
+            );
+            let out = Value::list(lines.borrow().clone());
+            out
+        };
+        for (label, b, a) in [("after", false, true), ("before", true, false), ("both", true, true)] {
+            let got = mk_log(&input, b, a);
+            let exp = vget(&want, label);
+            if got == exp {
+                run.passed += 1;
+            } else {
+                run.failures.push(format!(
+                    "walk-log/{label}: got {}, want {}",
+                    stringify(&got, Some(220), false),
+                    stringify(&exp, Some(220), false)
+                ));
+            }
+        }
+    }
+    // walk.depth — reconstruct `src` truncated at `maxdepth`.
+    run.run_set(&set!("walk", "depth"), false, "walk-depth", |vin| {
+        let top: Rc<RefCell<Value>> = Rc::new(RefCell::new(Value::Noval));
+        let cur: Rc<RefCell<Value>> = Rc::new(RefCell::new(Value::Noval));
+        let (t, c) = (top.clone(), cur.clone());
+        let mut copy = move |k: &Value, val: &Value, _p: &Value, _path: &[String]| -> Value {
+            if k.is_noval() || matches!(val, Value::List(_) | Value::Map(_)) {
+                let child = if matches!(val, Value::List(_)) {
+                    Value::empty_list()
+                } else {
+                    Value::empty_map()
+                };
+                if k.is_noval() {
+                    *t.borrow_mut() = child.clone();
+                    *c.borrow_mut() = child;
+                } else {
+                    let curv = c.borrow().clone();
+                    set_prop(curv, k, child.clone());
+                    *c.borrow_mut() = child;
+                }
+            } else {
+                let curv = c.borrow().clone();
+                set_prop(curv, k, val.clone());
+            }
+            val.clone()
+        };
+        let _ = walk(vget(&vin, "src"), Some(&mut copy), None, as_i64_opt(&vget(&vin, "maxdepth")));
+        let r = top.borrow().clone();
+        r
+    });
+    // walk.copy — deep-copy via a depth-indexed scratch list.
+    run.run_set(&set!("walk", "copy"), true, "walk-copy", |vin| {
+        let cur: Rc<RefCell<Vec<Value>>> = Rc::new(RefCell::new(Vec::new()));
+        let c = cur.clone();
+        let mut walkcopy = move |k: &Value, val: &Value, _p: &Value, path: &[String]| -> Value {
+            if k.is_noval() {
+                let head = match val {
+                    Value::Map(_) => Value::empty_map(),
+                    Value::List(_) => Value::empty_list(),
+                    other => other.clone(),
+                };
+                *c.borrow_mut() = vec![head];
+                return val.clone();
+            }
+            let i = path.len();
+            let mut v = val.clone();
+            if matches!(val, Value::List(_) | Value::Map(_)) {
+                v = if is_map(val) { Value::empty_map() } else { Value::empty_list() };
+                let mut cb = c.borrow_mut();
+                while cb.len() <= i {
+                    cb.push(Value::Noval);
+                }
+                cb[i] = v.clone();
+            }
+            let parent_copy = c.borrow().get(i.saturating_sub(1)).cloned().unwrap_or(Value::Noval);
+            set_prop(parent_copy, k, v);
+            val.clone()
+        };
+        let _ = walk(vin, Some(&mut walkcopy), None, None);
+        let r = cur.borrow().first().cloned().unwrap_or(Value::Noval);
+        r
+    });
 
     // -------- merge --------------------------------------------------
     for name in ["cases", "array", "integrity"] {
         run.run_set(&set!("merge", name), true, &format!("merge-{name}"), |vin| merge(&vin, None));
     }
+    run.run_set(&set!("merge", "depth"), true, "merge-depth", |vin| {
+        merge(&vget(&vin, "val"), as_i64_opt(&vget(&vin, "depth")))
+    });
     // merge.basic is a single { in, out } object (not a `set`); handle inline.
     {
         let mb = vget(&s, "merge");

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -222,6 +222,107 @@ impl Run {
     }
 }
 
+impl Run {
+    /// Like `run_set`, but the subject may return `Err(message)` — matched
+    /// (substring / regex, case-insensitive) against the entry's `err` field.
+    fn run_set_fallible<F>(&mut self, set: &Value, null_flag: bool, label: &str, mut subject: F)
+    where
+        F: FnMut(Value) -> Result<Value, String>,
+    {
+        let fixed = fix_json(set, null_flag);
+        let testset = vget(&fixed, "set");
+        let entries = match testset.as_list() {
+            Some(l) => l.borrow().clone(),
+            None => {
+                self.failures.push(format!("{label}: no `set` array"));
+                return;
+            }
+        };
+        for (i, entry) in entries.iter().enumerate() {
+            let out0 = vget(entry, "out");
+            let expected = if out0.is_noval() && null_flag {
+                Value::str(NULLMARK)
+            } else {
+                out0
+            };
+            let err_expected = vget(entry, "err");
+            let match_spec = vget(entry, "match");
+            let vin = clone(&vget(entry, "in"));
+            let result = subject(vin.clone());
+
+            match result {
+                Err(msg) => {
+                    if err_expected.is_noval() {
+                        self.failures.push(format!("{label}#{i}: unexpected error: {msg}"));
+                        continue;
+                    }
+                    let want = match &err_expected {
+                        Value::Bool(true) => {
+                            self.passed += 1;
+                            continue;
+                        }
+                        Value::Str(s) => s.clone(),
+                        other => stringify(other, None, false),
+                    };
+                    let ok = if let Some(rem) =
+                        want.strip_prefix('/').and_then(|s| s.strip_suffix('/'))
+                    {
+                        regex::Regex::new(rem).map(|re| re.is_match(&msg)).unwrap_or(false)
+                    } else {
+                        msg.to_lowercase().contains(&want.to_lowercase())
+                    };
+                    if ok {
+                        self.passed += 1;
+                    } else {
+                        self.failures.push(format!(
+                            "{label}#{i}: error mismatch: got [{}] want [{}]",
+                            msg, want
+                        ));
+                    }
+                }
+                Ok(v) => {
+                    if !err_expected.is_noval() {
+                        self.failures.push(format!(
+                            "{label}#{i}: expected error [{}] but got value {}",
+                            stringify(&err_expected, Some(80), false),
+                            stringify(&fix_json(&v, null_flag), Some(80), false)
+                        ));
+                        continue;
+                    }
+                    let res = fix_json(&v, null_flag);
+                    let mut matched = false;
+                    if !match_spec.is_noval() {
+                        let mut base = IndexMap::new();
+                        base.insert("in".to_string(), vget(entry, "in"));
+                        base.insert("args".to_string(), Value::list(vec![vin.clone()]));
+                        base.insert("out".to_string(), res.clone());
+                        let base = Value::map(base);
+                        if let Some(why) = match_check(&match_spec, &base) {
+                            self.failures.push(format!("{label}#{i}: match failed ({why})"));
+                            continue;
+                        }
+                        matched = true;
+                    }
+                    if res == expected
+                        || (matched
+                            && (expected == Value::str(NULLMARK)
+                                || expected.is_nullish()))
+                    {
+                        self.passed += 1;
+                    } else {
+                        self.failures.push(format!(
+                            "{label}#{i}: in={} -> got {}, want {}",
+                            stringify(&vget(entry, "in"), Some(120), false),
+                            stringify(&res, Some(120), false),
+                            stringify(&expected, Some(120), false),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Walk `check`; every leaf must equal/match `getpath(base, path)`. Returns
 /// `Some(reason)` on the first mismatch, `None` if all leaves match.
 fn match_check(check: &Value, base: &Value) -> Option<String> {
@@ -549,12 +650,17 @@ fn corpus() {
             ));
         }
     }
-    for name in ["paths", "cmds"] {
-        run.run_set(&set!("transform", name), true, &format!("transform-{name}"), |vin| {
-            match transform(&vget(&vin, "data"), &vget(&vin, "spec"), None) {
-                Ok(v) => v,
-                Err(_) => Value::Noval,
-            }
+    for (name, null_flag) in [
+        ("paths", true),
+        ("cmds", true),
+        ("ref", true),
+        ("each", true),
+        ("pack", true),
+        ("format", false),
+        ("apply", true),
+    ] {
+        run.run_set_fallible(&set!("transform", name), null_flag, &format!("transform-{name}"), |vin| {
+            transform(&vget(&vin, "data"), &vget(&vin, "spec"), None).map_err(|e| e.message)
         });
     }
     run.run_set(&set!("transform", "modify"), true, "transform-modify", |vin| {
@@ -570,6 +676,22 @@ fn corpus() {
             Ok(v) => v,
             Err(_) => Value::Noval,
         }
+    });
+
+    // -------- validate -----------------------------------------------
+    for name in ["basic", "invalid"] {
+        run.run_set_fallible(&set!("validate", name), false, &format!("validate-{name}"), |vin| {
+            validate(&vget(&vin, "data"), &vget(&vin, "spec"), None).map_err(|e| e.message)
+        });
+    }
+    for name in ["child", "one", "exact"] {
+        run.run_set_fallible(&set!("validate", name), true, &format!("validate-{name}"), |vin| {
+            validate(&vget(&vin, "data"), &vget(&vin, "spec"), None).map_err(|e| e.message)
+        });
+    }
+    run.run_set_fallible(&set!("validate", "special"), true, "validate-special", |vin| {
+        let d = inject_def_from_value(&vget(&vin, "inj"));
+        validate(&vget(&vin, "data"), &vget(&vin, "spec"), Some(&d)).map_err(|e| e.message)
     });
 
     // -------- report -------------------------------------------------

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -694,6 +694,13 @@ fn corpus() {
         validate(&vget(&vin, "data"), &vget(&vin, "spec"), Some(&d)).map_err(|e| e.message)
     });
 
+    // -------- select -------------------------------------------------
+    for name in ["basic", "operators", "edge", "alts"] {
+        run.run_set(&set!("select", name), true, &format!("select-{name}"), |vin| {
+            select(&vget(&vin, "obj"), &vget(&vin, "query"))
+        });
+    }
+
     // -------- report -------------------------------------------------
     if !run.failures.is_empty() {
         let n = run.failures.len();

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -491,6 +491,87 @@ fn corpus() {
         get_path(&store, &vget(&vin, "path"), Some(&d))
     });
 
+    // -------- inject -------------------------------------------------
+    {
+        // inject.basic is a single { in: {val, store}, out } object.
+        let basic = vget_path(&s, &["inject", "basic"]);
+        let bin = vget(&basic, "in");
+        let bout = fix_json(&vget(&basic, "out"), true);
+        let got = fix_json(
+            &inject(clone(&vget(&bin, "val")), &clone(&vget(&bin, "store")), None),
+            true,
+        );
+        if got == bout {
+            run.passed += 1;
+        } else {
+            run.failures.push(format!(
+                "inject-basic: got {}, want {}",
+                stringify(&got, Some(200), false),
+                stringify(&bout, Some(200), false)
+            ));
+        }
+    }
+    run.run_set(&set!("inject", "string"), true, "inject-string", |vin| {
+        let null_mod: Modify = Rc::new(
+            |val: &Value, key: &Value, parent: &Value, _inj: &Inj, _store: &Value| {
+                if let Value::Str(svv) = val {
+                    if svv == NULLMARK {
+                        set_prop(parent.clone(), key, Value::Null);
+                    } else {
+                        set_prop(parent.clone(), key, Value::str(svv.replace(NULLMARK, "null")));
+                    }
+                }
+            },
+        );
+        let d = InjectDef { modify: Some(null_mod), ..Default::default() };
+        inject(vget(&vin, "val"), &vget(&vin, "store"), Some(&d))
+    });
+    run.run_set(&set!("inject", "deep"), true, "inject-deep", |vin| {
+        inject(vget(&vin, "val"), &vget(&vin, "store"), None)
+    });
+
+    // -------- transform ---------------------------------------------
+    {
+        let basic = vget_path(&s, &["transform", "basic"]);
+        let bin = vget(&basic, "in");
+        let bout = fix_json(&vget(&basic, "out"), true);
+        let got = match transform(&clone(&vget(&bin, "data")), &clone(&vget(&bin, "spec")), None) {
+            Ok(v) => fix_json(&v, true),
+            Err(e) => Value::str(format!("ERR:{}", e)),
+        };
+        if got == bout {
+            run.passed += 1;
+        } else {
+            run.failures.push(format!(
+                "transform-basic: got {}, want {}",
+                stringify(&got, Some(200), false),
+                stringify(&bout, Some(200), false)
+            ));
+        }
+    }
+    for name in ["paths", "cmds"] {
+        run.run_set(&set!("transform", name), true, &format!("transform-{name}"), |vin| {
+            match transform(&vget(&vin, "data"), &vget(&vin, "spec"), None) {
+                Ok(v) => v,
+                Err(_) => Value::Noval,
+            }
+        });
+    }
+    run.run_set(&set!("transform", "modify"), true, "transform-modify", |vin| {
+        let m: Modify = Rc::new(
+            |val: &Value, key: &Value, parent: &Value, _inj: &Inj, _store: &Value| {
+                if let Value::Str(svv) = val {
+                    set_prop(parent.clone(), key, Value::str(format!("@{svv}")));
+                }
+            },
+        );
+        let d = InjectDef { modify: Some(m), ..Default::default() };
+        match transform(&vget(&vin, "data"), &vget(&vin, "spec"), Some(&d)) {
+            Ok(v) => v,
+            Err(_) => Value::Noval,
+        }
+    });
+
     // -------- report -------------------------------------------------
     if !run.failures.is_empty() {
         let n = run.failures.len();

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -1,0 +1,520 @@
+// Corpus test runner — drives the shared JSON test corpus
+// (../build/test/test.json) against the Rust port. Mirrors
+// ts/test/runner.ts + ts/test/utility/StructUtility.test.ts.
+//
+// Only the implemented subsets are wired here: minor utilities, walk, merge,
+// getpath, setpath. inject / transform / validate / select (and the
+// top-level `primary` SDK tests) are staged; see rs/NOTES.md.
+
+use std::cell::RefCell;
+use std::fs;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use indexmap::IndexMap;
+use serde_json::Value as J;
+
+use voxgig_struct::value::Value;
+use voxgig_struct::*;
+
+const NULLMARK: &str = "__NULL__";
+const UNDEFMARK: &str = "__UNDEF__";
+const EXISTSMARK: &str = "__EXISTS__";
+
+// ---- JSON -> Value -----------------------------------------------------
+
+fn j_to_v(j: &J) -> Value {
+    match j {
+        J::Null => Value::Null,
+        J::Bool(b) => Value::Bool(*b),
+        J::Number(n) => Value::Num(n.as_f64().unwrap_or(f64::NAN)),
+        J::String(s) => Value::Str(s.clone()),
+        J::Array(a) => Value::list(a.iter().map(j_to_v).collect()),
+        J::Object(o) => {
+            let mut m = IndexMap::new();
+            for (k, v) in o.iter() {
+                m.insert(k.clone(), j_to_v(v));
+            }
+            Value::map(m)
+        }
+    }
+}
+
+fn test_json() -> Value {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("..");
+    p.push("build");
+    p.push("test");
+    p.push("test.json");
+    let txt = fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {:?}: {e}", p));
+    let j: J = serde_json::from_str(&txt).expect("parse test.json");
+    j_to_v(&j)
+}
+
+// ---- value helpers -----------------------------------------------------
+
+fn vget(v: &Value, key: &str) -> Value {
+    get_prop(v, &Value::str(key), Value::Noval)
+}
+
+fn vget_path(v: &Value, keys: &[&str]) -> Value {
+    let mut cur = v.clone();
+    for k in keys {
+        cur = vget(&cur, k);
+    }
+    cur
+}
+
+fn as_i64_opt(v: &Value) -> Option<i64> {
+    match v {
+        Value::Num(n) => Some(*n as i64),
+        _ => None,
+    }
+}
+
+fn as_str_opt(v: &Value) -> Option<String> {
+    match v {
+        Value::Str(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+// fixJSON: deep-replace JSON null (and undefined) with NULLMARK (when
+// null_flag). Matches `JSON.parse(JSON.stringify(val, replacer))` with the
+// null->NULLMARK replacer used by ts/test/runner.ts.
+fn fix_json(v: &Value, null_flag: bool) -> Value {
+    match v {
+        Value::Null | Value::Noval => {
+            if null_flag {
+                Value::str(NULLMARK)
+            } else {
+                v.clone()
+            }
+        }
+        Value::List(l) => Value::list(l.borrow().iter().map(|x| fix_json(x, null_flag)).collect()),
+        Value::Map(m) => {
+            let mut nm = IndexMap::new();
+            for (k, x) in m.borrow().iter() {
+                nm.insert(k.clone(), fix_json(x, null_flag));
+            }
+            Value::map(nm)
+        }
+        Value::Func(_) => {
+            // JSON.stringify drops functions (object key) / -> null (array elem).
+            // At the comparison boundary, treat as null-ish.
+            if null_flag {
+                Value::str(NULLMARK)
+            } else {
+                Value::Null
+            }
+        }
+        other => other.clone(),
+    }
+}
+
+// match check for the `match` field of a test entry (substring / regex / etc).
+fn matchval(check: &Value, base: &Value) -> bool {
+    if check == base {
+        return true;
+    }
+    if let Value::Str(cs) = check {
+        let bstr = stringify(base, None, false);
+        if let Some(rem) = cs.strip_prefix('/').and_then(|s| s.strip_suffix('/')) {
+            if let Ok(re) = regex::Regex::new(rem) {
+                return re.is_match(&bstr);
+            }
+        }
+        return bstr
+            .to_lowercase()
+            .contains(&stringify(check, None, false).to_lowercase());
+    }
+    false
+}
+
+// ---- the test loop -----------------------------------------------------
+
+struct Run {
+    failures: Vec<String>,
+    passed: usize,
+}
+
+impl Run {
+    fn new() -> Self {
+        Run { failures: Vec::new(), passed: 0 }
+    }
+
+    /// Run a test set: `label` for messages, `null_flag` matches the TS
+    /// `flags.null` (`runset` => true, `runsetflags({null:false})` => false),
+    /// `subject` takes the (cloned) `vin` and returns the result Value.
+    fn run_set<F>(&mut self, set: &Value, null_flag: bool, label: &str, mut subject: F)
+    where
+        F: FnMut(Value) -> Value,
+    {
+        let fixed = fix_json(set, null_flag);
+        let testset = vget(&fixed, "set");
+        let entries = match testset.as_list() {
+            Some(l) => l.borrow().clone(),
+            None => {
+                self.failures.push(format!("{label}: no `set` array"));
+                return;
+            }
+        };
+        for (i, entry) in entries.iter().enumerate() {
+            // resolveEntry: missing `out` + null_flag => NULLMARK
+            let out0 = vget(entry, "out");
+            let expected = if out0.is_noval() && null_flag {
+                Value::str(NULLMARK)
+            } else {
+                out0
+            };
+            let err_expected = vget(entry, "err");
+            let match_spec = vget(entry, "match");
+
+            // `vin` = clone(entry.in) (deep). The subject gets a shallow
+            // Rc-clone of it, so any in-place mutation it makes (setpath,
+            // setprop, …) is visible through `vin` afterwards.
+            let vin = clone(&vget(entry, "in"));
+            let res = fix_json(&subject(vin.clone()), null_flag);
+
+            if !err_expected.is_noval() {
+                self.failures.push(format!(
+                    "{label}#{i}: expected error [{}] but got {}",
+                    stringify(&err_expected, Some(80), false),
+                    stringify(&res, Some(80), false),
+                ));
+                continue;
+            }
+
+            let mut matched = false;
+            if !match_spec.is_noval() {
+                // base = { in: entry.in (original), args: [vin (post-call)], out: res }
+                let mut base = IndexMap::new();
+                base.insert("in".to_string(), vget(entry, "in"));
+                base.insert("args".to_string(), Value::list(vec![vin.clone()]));
+                base.insert("out".to_string(), res.clone());
+                let base = Value::map(base);
+                if let Some(why) = match_check(&match_spec, &base) {
+                    self.failures.push(format!(
+                        "{label}#{i}: match failed ({why}); got {}",
+                        stringify(&res, Some(160), false)
+                    ));
+                    continue;
+                }
+                matched = true;
+            }
+
+            if res == expected {
+                self.passed += 1;
+                continue;
+            }
+            if matched && (expected == Value::str(NULLMARK) || expected.is_noval() || expected.is_null()) {
+                self.passed += 1;
+                continue;
+            }
+
+            self.failures.push(format!(
+                "{label}#{i}: in={} -> got {}, want {}",
+                stringify(&vget(entry, "in"), Some(120), false),
+                stringify(&res, Some(120), false),
+                stringify(&expected, Some(120), false),
+            ));
+        }
+    }
+}
+
+/// Walk `check`; every leaf must equal/match `getpath(base, path)`. Returns
+/// `Some(reason)` on the first mismatch, `None` if all leaves match.
+fn match_check(check: &Value, base: &Value) -> Option<String> {
+    fn rec(check: &Value, base: &Value, path: &mut Vec<String>) -> Option<String> {
+        match check {
+            Value::Map(cm) => {
+                for (k, cv) in cm.borrow().iter() {
+                    path.push(k.clone());
+                    let r = rec(cv, base, path);
+                    path.pop();
+                    if r.is_some() {
+                        return r;
+                    }
+                }
+                None
+            }
+            Value::List(cl) => {
+                for (i, cv) in cl.borrow().iter().enumerate() {
+                    path.push(i.to_string());
+                    let r = rec(cv, base, path);
+                    path.pop();
+                    if r.is_some() {
+                        return r;
+                    }
+                }
+                None
+            }
+            leaf => {
+                let bv = get_path(
+                    base,
+                    &Value::list(path.iter().cloned().map(Value::Str).collect()),
+                    None,
+                );
+                if leaf == &bv {
+                    return None;
+                }
+                if let Value::Str(s) = leaf {
+                    if s == UNDEFMARK && bv.is_noval() {
+                        return None;
+                    }
+                    if s == EXISTSMARK && !bv.is_nullish() {
+                        return None;
+                    }
+                }
+                if matchval(leaf, &bv) {
+                    return None;
+                }
+                Some(format!(
+                    "{}: {} <=> {}",
+                    path.join("."),
+                    stringify(leaf, Some(40), false),
+                    stringify(&bv, Some(40), false)
+                ))
+            }
+        }
+    }
+    let mut path = Vec::new();
+    rec(check, base, &mut path)
+}
+
+// ---- adapters helpers --------------------------------------------------
+
+fn b(v: bool) -> Value {
+    Value::Bool(v)
+}
+
+fn inject_def_from_value(v: &Value) -> InjectDef {
+    let mut d = InjectDef::default();
+    if let Value::Map(_) = v {
+        let key = vget(v, "key");
+        if !key.is_noval() {
+            d.key = Some(key);
+        }
+        let meta = vget(v, "meta");
+        if !meta.is_noval() {
+            d.meta = Some(meta);
+        }
+        let base = vget(v, "base");
+        if let Value::Str(s) = base {
+            d.base = Some(s);
+        }
+        let dparent = vget(v, "dparent");
+        if !dparent.is_noval() {
+            d.dparent = Some(dparent);
+        }
+        let dpath = vget(v, "dpath");
+        if let Value::Str(s) = dpath {
+            d.dpath = Some(s.split('.').map(|x| x.to_string()).collect());
+        } else if let Value::List(l) = &dpath {
+            d.dpath = Some(l.borrow().iter().map(|x| as_str_opt(x).unwrap_or_default()).collect());
+        }
+    }
+    d
+}
+
+// ---- the test -----------------------------------------------------------
+
+#[test]
+fn corpus() {
+    let spec = test_json();
+    let s = vget(&spec, "struct");
+    let mut run = Run::new();
+
+    macro_rules! set {
+        ($cat:expr, $name:expr) => {
+            vget_path(&s, &[$cat, $name])
+        };
+    }
+
+    // -------- minor --------------------------------------------------
+    run.run_set(&set!("minor", "isnode"), true, "minor-isnode", |v| b(is_node(&v)));
+    run.run_set(&set!("minor", "ismap"), true, "minor-ismap", |v| b(is_map(&v)));
+    run.run_set(&set!("minor", "islist"), true, "minor-islist", |v| b(is_list(&v)));
+    run.run_set(&set!("minor", "iskey"), false, "minor-iskey", |v| b(is_key(&v)));
+    run.run_set(&set!("minor", "strkey"), false, "minor-strkey", |v| Value::str(str_key(v)));
+    run.run_set(&set!("minor", "isempty"), false, "minor-isempty", |v| b(is_empty(&v)));
+    run.run_set(&set!("minor", "isfunc"), true, "minor-isfunc", |v| b(is_func(&v)));
+    run.run_set(&set!("minor", "clone"), false, "minor-clone", |v| clone(&v));
+    run.run_set(&set!("minor", "filter"), true, "minor-filter", |vin| {
+        let val = vget(&vin, "val");
+        let check = as_str_opt(&vget(&vin, "check")).unwrap_or_default();
+        filter(&val, move |n| match check.as_str() {
+            "gt3" => matches!(&n.1, Value::Num(x) if *x > 3.0),
+            "lt3" => matches!(&n.1, Value::Num(x) if *x < 3.0),
+            _ => false,
+        })
+    });
+    run.run_set(&set!("minor", "flatten"), true, "minor-flatten", |vin| {
+        flatten(&vget(&vin, "val"), as_i64_opt(&vget(&vin, "depth")))
+    });
+    run.run_set(&set!("minor", "escre"), true, "minor-escre", |v| Value::str(esc_re(&v)));
+    run.run_set(&set!("minor", "escurl"), true, "minor-escurl", |v| Value::str(esc_url(&v)));
+    run.run_set(&set!("minor", "stringify"), true, "minor-stringify", |vin| {
+        let mut val = vget(&vin, "val");
+        if val == Value::str(NULLMARK) {
+            val = Value::str("null");
+        }
+        Value::str(stringify(&val, as_i64_opt(&vget(&vin, "max")), false))
+    });
+    run.run_set(&set!("minor", "jsonify"), false, "minor-jsonify", |vin| {
+        let flags_v = vget(&vin, "flags");
+        let flags = if flags_v.is_noval() {
+            None
+        } else {
+            let indent = as_i64_opt(&vget(&flags_v, "indent")).unwrap_or(2).max(0) as usize;
+            let offset = as_i64_opt(&vget(&flags_v, "offset")).unwrap_or(0).max(0) as usize;
+            Some(JsonFlags { indent, offset })
+        };
+        Value::str(jsonify(&vget(&vin, "val"), flags.as_ref()))
+    });
+    run.run_set(&set!("minor", "pathify"), true, "minor-pathify", |vin| {
+        let pathv = vget(&vin, "path");
+        let path = if pathv == Value::str(NULLMARK) { Value::Noval } else { pathv.clone() };
+        let mut ps = pathify(&path, as_i64_opt(&vget(&vin, "from")), None);
+        ps = ps.replace("__NULL__.", "");
+        if pathv == Value::str(NULLMARK) {
+            ps = ps.replace('>', ":null>");
+        }
+        Value::str(ps)
+    });
+    run.run_set(&set!("minor", "items"), true, "minor-items", |v| items(&v));
+    run.run_set(&set!("minor", "getelem"), false, "minor-getelem", |vin| {
+        let alt = vget(&vin, "alt");
+        get_elem(&vget(&vin, "val"), &vget(&vin, "key"), alt)
+    });
+    run.run_set(&set!("minor", "getprop"), false, "minor-getprop", |vin| {
+        let alt = vget(&vin, "alt");
+        get_prop(&vget(&vin, "val"), &vget(&vin, "key"), alt)
+    });
+    run.run_set(&set!("minor", "setprop"), true, "minor-setprop", |vin| {
+        set_prop(vget(&vin, "parent"), &vget(&vin, "key"), vget(&vin, "val"))
+    });
+    run.run_set(&set!("minor", "delprop"), true, "minor-delprop", |vin| {
+        del_prop(vget(&vin, "parent"), &vget(&vin, "key"))
+    });
+    run.run_set(&set!("minor", "haskey"), false, "minor-haskey", |vin| {
+        b(has_key(&vget(&vin, "src"), &vget(&vin, "key")))
+    });
+    run.run_set(&set!("minor", "keysof"), true, "minor-keysof", |v| keys_of(&v));
+    run.run_set(&set!("minor", "join"), false, "minor-join", |vin| {
+        let val = vget(&vin, "val");
+        let sep = as_str_opt(&vget(&vin, "sep"));
+        let url = matches!(vget(&vin, "url"), Value::Bool(true));
+        Value::str(join(&val, sep.as_deref(), url))
+    });
+    run.run_set(&set!("minor", "typename"), true, "minor-typename", |v| {
+        Value::str(type_name(v.as_num().unwrap_or(0.0) as i64))
+    });
+    run.run_set(&set!("minor", "typify"), false, "minor-typify", |v| Value::Num(typify(&v) as f64));
+    run.run_set(&set!("minor", "size"), false, "minor-size", |v| Value::Num(size(&v) as f64));
+    run.run_set(&set!("minor", "slice"), false, "minor-slice", |vin| {
+        slice(vget(&vin, "val"), as_i64_opt(&vget(&vin, "start")), as_i64_opt(&vget(&vin, "end")), false)
+    });
+    run.run_set(&set!("minor", "pad"), false, "minor-pad", |vin| {
+        Value::str(pad(vget(&vin, "val"), as_i64_opt(&vget(&vin, "pad")), as_str_opt(&vget(&vin, "char"))))
+    });
+    run.run_set(&set!("minor", "setpath"), false, "minor-setpath", |vin| {
+        set_path(&vget(&vin, "store"), &vget(&vin, "path"), vget(&vin, "val"), None)
+    });
+
+    // -------- walk ---------------------------------------------------
+    run.run_set(&set!("walk", "basic"), true, "walk-basic", |vin| {
+        let mut walkpath = |_k: &Value, val: &Value, _p: &Value, path: &[String]| -> Value {
+            match val {
+                Value::Str(sv) => Value::str(format!("{}~{}", sv, path.join("."))),
+                _ => val.clone(),
+            }
+        };
+        walk(vin, Some(&mut walkpath), None, None)
+    });
+
+    // -------- merge --------------------------------------------------
+    for name in ["cases", "array", "integrity"] {
+        run.run_set(&set!("merge", name), true, &format!("merge-{name}"), |vin| merge(&vin, None));
+    }
+    // merge.basic is a single { in, out } object (not a `set`); handle inline.
+    {
+        let mb = vget(&s, "merge");
+        let basic = vget(&mb, "basic");
+        let bin = clone(&vget(&basic, "in"));
+        let bout = fix_json(&vget(&basic, "out"), true);
+        let got = fix_json(&merge(&bin, None), true);
+        if got == bout {
+            run.passed += 1;
+        } else {
+            run.failures.push(format!(
+                "merge-basic: got {}, want {}",
+                stringify(&got, Some(200), false),
+                stringify(&bout, Some(200), false)
+            ));
+        }
+    }
+
+    // -------- getpath ------------------------------------------------
+    run.run_set(&set!("getpath", "basic"), true, "getpath-basic", |vin| {
+        get_path(&vget(&vin, "store"), &vget(&vin, "path"), None)
+    });
+    run.run_set(&set!("getpath", "relative"), true, "getpath-relative", |vin| {
+        let mut d = InjectDef::default();
+        d.dparent = Some(vget(&vin, "dparent"));
+        if let Value::Str(dp) = vget(&vin, "dpath") {
+            d.dpath = Some(dp.split('.').map(|x| x.to_string()).collect());
+        }
+        get_path(&vget(&vin, "store"), &vget(&vin, "path"), Some(&d))
+    });
+    run.run_set(&set!("getpath", "special"), true, "getpath-special", |vin| {
+        let d = inject_def_from_value(&vget(&vin, "inj"));
+        get_path(&vget(&vin, "store"), &vget(&vin, "path"), Some(&d))
+    });
+    run.run_set(&set!("getpath", "handler"), true, "getpath-handler", |vin| {
+        // getpath({ $TOP: store, $FOO: () => 'foo' }, path, { handler: (_inj, val) => val() })
+        let store_inner = vget(&vin, "store");
+        let mut topmap = IndexMap::new();
+        topmap.insert("$TOP".to_string(), store_inner);
+        topmap.insert(
+            "$FOO".to_string(),
+            Value::func(|_inj: &Inj, _v: &Value, _r: &str, _st: &Value| Value::str("foo")),
+        );
+        let store = Value::map(topmap);
+        let handler: NativeFn = Rc::new(|inj: &Inj, val: &Value, _r: &str, st: &Value| -> Value {
+            match val {
+                Value::Func(f) => f(inj, &Value::Noval, "", st),
+                other => other.clone(),
+            }
+        });
+        let d = InjectDef { handler: Some(handler), ..Default::default() };
+        get_path(&store, &vget(&vin, "path"), Some(&d))
+    });
+
+    // -------- report -------------------------------------------------
+    if !run.failures.is_empty() {
+        let n = run.failures.len();
+        let mut msg = format!(
+            "\n{} corpus check(s) failed ({} passed):\n",
+            n, run.passed
+        );
+        for f in run.failures.iter().take(60) {
+            msg.push_str("  - ");
+            msg.push_str(f);
+            msg.push('\n');
+        }
+        if n > 60 {
+            msg.push_str(&format!("  ... and {} more\n", n - 60));
+        }
+        panic!("{msg}");
+    }
+    eprintln!("corpus: {} checks passed", run.passed);
+}
+
+// quiet unused-import warnings for the staged bits
+#[allow(dead_code)]
+fn _unused() {
+    let _ = (UNDEFMARK, EXISTSMARK);
+    let _ = Rc::new(RefCell::new(0));
+    let _ = Value::Noval;
+}

--- a/rs/tests/corpus.rs
+++ b/rs/tests/corpus.rs
@@ -561,11 +561,15 @@ fn corpus() {
         get_path(&vget(&vin, "store"), &vget(&vin, "path"), None)
     });
     run.run_set(&set!("getpath", "relative"), true, "getpath-relative", |vin| {
-        let mut d = InjectDef::default();
-        d.dparent = Some(vget(&vin, "dparent"));
-        if let Value::Str(dp) = vget(&vin, "dpath") {
-            d.dpath = Some(dp.split('.').map(|x| x.to_string()).collect());
-        }
+        let dpath = match vget(&vin, "dpath") {
+            Value::Str(dp) => Some(dp.split('.').map(|x| x.to_string()).collect()),
+            _ => None,
+        };
+        let d = InjectDef {
+            dparent: Some(vget(&vin, "dparent")),
+            dpath,
+            ..Default::default()
+        };
         get_path(&vget(&vin, "store"), &vget(&vin, "path"), Some(&d))
     });
     run.run_set(&set!("getpath", "special"), true, "getpath-special", |vin| {
@@ -699,6 +703,64 @@ fn corpus() {
         run.run_set(&set!("select", name), true, &format!("select-{name}"), |vin| {
             select(&vget(&vin, "obj"), &vget(&vin, "query"))
         });
+    }
+
+    // -------- primary / SDK ------------------------------------------
+    // A tiny mock SDK (mirrors ts/test/sdk.ts): check(ctx) ->
+    //   { zed: 'ZED' + (opts.foo ?? '') + '_' + (ctx.meta?.bar ?? '0') }
+    fn sdk_check(opts: &Value, ctx: &Value) -> Value {
+        let foo = get_prop(opts, &Value::str("foo"), Value::Noval);
+        let foo_s = if foo.is_nullish() {
+            String::new()
+        } else {
+            voxgig_struct::value::js_string(&foo)
+        };
+        let bar = get_path(ctx, &Value::str("meta.bar"), None);
+        let bar_s = if bar.is_nullish() {
+            "0".to_string()
+        } else {
+            voxgig_struct::value::js_string(&bar)
+        };
+        Value::map_of([(
+            "zed".to_string(),
+            Value::str(format!("ZED{foo_s}_{bar_s}")),
+        )])
+    }
+    {
+        let check = vget_path(&spec, &["primary", "check"]);
+        // resolve clients from DEF.client (options are inject()'d against {} — a no-op here)
+        let def_clients = vget_path(&check, &["DEF", "client"]);
+        let mut clients: IndexMap<String, Value> = IndexMap::new();
+        if let Value::Map(m) = &def_clients {
+            for (cn, cdef) in m.borrow().iter() {
+                let opts = vget_path(cdef, &["test", "options"]);
+                let opts = inject(clone(&opts), &Value::empty_map(), None);
+                clients.insert(cn.clone(), opts);
+            }
+        }
+        let basic = vget(&check, "basic");
+        let testset = vget(&basic, "set");
+        if let Some(l) = testset.as_list() {
+            for (i, entry) in l.borrow().iter().enumerate() {
+                let ctx = vget(entry, "ctx");
+                let client = vget(entry, "client");
+                let opts = match &client {
+                    Value::Str(c) => clients.get(c).cloned().unwrap_or(Value::empty_map()),
+                    _ => Value::empty_map(),
+                };
+                let res = fix_json(&sdk_check(&opts, &ctx), true);
+                let want = fix_json(&vget(entry, "out"), true);
+                if res == want {
+                    run.passed += 1;
+                } else {
+                    run.failures.push(format!(
+                        "check-basic#{i}: got {}, want {}",
+                        stringify(&res, Some(120), false),
+                        stringify(&want, Some(120), false)
+                    ));
+                }
+            }
+        }
     }
 
     // -------- report -------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds a complete, production-ready Rust port of the canonical TypeScript Struct implementation. The port passes the full shared corpus (1187 test checks) and implements all major subsystems: value types, minor utilities, walk/merge operations, path access, injection state machine, transform commands, validation checkers, and selection operators.

## Key Changes

- **New `rs/` directory** with complete Rust implementation:
  - `src/value.rs`: Custom `Value` enum supporting JSON-shaped data with reference-stable mutable lists/maps (`Rc<RefCell<…>>`), callables, and sentinels
  - `src/consts.rs`: Type bit-flags, mode flags, special string constants, and regex patterns
  - `src/mini.rs`: Minor utilities (type predicates, accessors, string/JSON helpers, slice/pad operations)
  - `src/major.rs`: Major utilities including `walk`, `merge`, `getpath`/`setpath`, and the `Injection` state machine for inject/transform/validate/select
  - `src/lib.rs`: Public API exports
  - `tests/corpus.rs`: Comprehensive test runner against the shared JSON corpus

- **Documentation**:
  - `rs/README.md`: Build/test instructions and API overview
  - `rs/PLAN.md`: Detailed porting plan, challenge analysis, and design decisions (e.g., why `Rc<RefCell<…>>` for reference stability, `IndexMap` for insertion order)
  - `rs/NOTES.md`: Implementation notes and divergences from TypeScript (idiomatic snake_case naming, direct recursion for merge, etc.)

- **Build configuration**:
  - `rs/Cargo.toml`: Package metadata and dependencies (indexmap, regex, serde_json, once_cell)
  - `rs/Makefile`: Build/test targets
  - Updated root `Makefile` and `.gitignore` to include Rust

- **Integration**:
  - Updated `REPORT.md` to reflect Rust port completion (1187/1187 corpus checks)
  - Updated top-level `README.md` to list Rust as a complete implementation

## Notable Implementation Details

- **Value type design**: Custom enum (not `serde_json::Value`) to support callables living inside data structures, sentinel identity preservation, and insertion-order preservation via `IndexMap`
- **Reference stability**: Lists and maps use `Rc<RefCell<…>>` to enable the library's core invariant of mutable, reference-stable nodes (required by `merge`, `inject`, and the `Injection` node stack)
- **Injection state machine**: Full implementation of the `Injection` struct with descent/child/setval operations, supporting the staged inject/transform/validate/select machinery
- **Walk-based merge**: `merge` implemented via `walk` with shared `cur`/`dst` scratch vectors passed through closures via `Rc<RefCell<…>>` (working around Rust's borrow checker)
- **Corpus-driven testing**: Test runner mirrors the TypeScript runner, handling null/undefined markers, regex/substring matching, and fallible operations

All code passes `cargo clippy` with no warnings.

https://claude.ai/code/session_01RdHy5dzQMcv3wcEbdxZrHn