### PR TITLE
design: analyse test spec model, propose type-based aontu structure

### DIFF
--- a/design/TESTSPEC_MODEL.md
+++ b/design/TESTSPEC_MODEL.md
@@ -132,7 +132,7 @@ accident rather than a designed slot.
 
 ### 3.5 Net: aontu is used as a glorified `#include`
 
-Of aontu's features, the corpus uses only `@` (import), one `&` template,
+Of aontu's features, the corpus uses only `@` (import), one `&:` map template,
 `$` absolute refs, and `key()`. Everything else is literal JSON. (Note: the
 `` `$STRING` ``/`` `$COPY` `` backtick tokens scattered through `validate.jsonic`
 and `transform.jsonic` are **struct's own** by-example sentinels — string
@@ -144,27 +144,45 @@ and `transform.jsonic` are **struct's own** by-example sentinels — string
 The goal is a model where the entry/group/spec shapes are **declared once as
 aontu types** and unified onto the data, so that (a) malformed entries fail at
 build time, (b) defaults are centralised, and (c) the structure documents
-itself. Below, "confident" = demonstrated in this repo; "verify" = standard
-unification-language features to confirm against the pinned `@voxgig/model`
-/ aontu version before relying on them, each with a fallback that needs only
-the confident set.
+itself.
 
-### 4.1 A shared schema unit
+The aontu features used below are confirmed from
+[`rjrodger/aontu`](https://github.com/rjrodger/aontu) `docs/reference-language.md`:
 
-Add one `build/test/schema.jsonic`, imported by `test.jsonic`, holding hidden
-**definitions** (names that unify into the data but are *projected out* of the
-emitted JSON — the property that keeps `test.json` byte-equivalent):
+| Feature | Syntax | Use here |
+|---|---|---|
+| scalar types | `string` `number` `integer` `boolean` `top` | constrain fields |
+| unification | `&` | apply a type to a value |
+| defaults | `*value` (e.g. `*false`) | centralise per-field defaults |
+| disjunction | `\|` (e.g. `string\|boolean`) | the exclusive input/expectation modes |
+| optional fields | `x?:` — *dropped if unresolved* | every non-required entry field |
+| map template | `&: {…}` — *template not emitted* | already used; extend it |
+| list template | `[ &:{…}, … ]` — *template not emitted* | type every `set` element |
+| references | `$.a.b` (absolute), `.a.b` (relative) | fixtures |
+| imports | `@"file"` | already used |
+| **`hide()`** | marks a value **excluded from output** | schema lives in the model, emits nothing |
+| **`close()`/`open()`** | closed vs. open struct | reject unknown fields (the typo guard) |
+| `key()` | ancestor key (`key(0)`=own) | already used (`name: key()`) |
+
+The two in bold are what make this both safe and worthwhile: `hide()` keeps the
+schema out of the compiled `test.json` (so the contract stays byte-equivalent),
+and `close()` is what actually rejects a typoed field.
+
+### 4.1 A shared, hidden schema unit
+
+Add one `build/test/schema.jsonic`, imported by `test.jsonic`, defining the
+types under a `hide()`-marked block so they participate in unification but emit
+nothing:
 
 ```jsonic
-# schema.jsonic — types only; emits nothing on its own.
+# schema.jsonic — hidden definitions; contribute constraints, emit no JSON.
 
-# An Entry: one call under test.
-Entry: {
-  # metadata
+Entry: close({
+  # metadata (optional, defaulted)
   id?:     string
-  doc?:    boolean
+  doc?:    *false & boolean
 
-  # input mode — exactly one of in | args | ctx
+  # input mode — exactly one of in | args | ctx (see §4.2)
   in?:     top
   args?:   list
   ctx?:    map
@@ -176,95 +194,88 @@ Entry: {
 
   # routing
   client?: string
-}
+})
 
-# A Group: a bucket of entries plus optional definitions/fixtures.
-Group: {
-  set:   [ ...Entry ]      # every element unified with Entry
-  DEF?:  map
-}
+Group: close({
+  set:      [ &:Entry ]   # the &: template unifies Entry into every element
+  fixtures?: map          # declared data slot (§4.4)
+  DEF?:      map          # declared definitions slot (§3.4)
+})
 ```
 
-* `?` optional fields + scalar atoms (`string`, `boolean`, `map`, `list`,
-  `top`) — **verify**. Fallback if aontu lacks `?`/atoms: drop the atoms and
-  keep `Entry` as a defaults-only template (§4.3); validation is then
-  structural (closedness) rather than per-field typed.
-* `[ ...Entry ]` list-element template (apply `Entry` to every `set` item) —
-  **verify** (this is the single highest-value feature here). Fallback: a
-  build-time check script (sibling to `tools/check_corpus_regex.py`) that
-  unifies each `set` element with `Entry` and reports failures, instead of
-  doing it inline.
+`close(...)` makes `{ otu: 42 }` a **build error** (unknown field in a closed
+struct) instead of a silent no-op test. `[ &:Entry ]` is aontu's list-template
+form: the leading `&:Entry` is consumed (not emitted) and unified into every
+real element — exactly the high-value guarantee the model lacks today.
 
 ### 4.2 Express the exclusive input / expectation modes
 
-If aontu supports disjunction of closed structs (**verify**), the
-"exactly-one-input" rule becomes declarative:
+Disjunction of closed structs makes the "exactly-one-input" rule — which today
+lives only in `resolveArgs`' precedence ladder — declarative:
 
 ```jsonic
-Entry: ({ in: top } | { args: list } | { ctx: map }) & {
-  id?: string,  doc?: boolean,  client?: string
-  out?: top,    err?: string|boolean,  match?: map
-}
+Entry: close(
+  ( { in: top } | { args: list } | { ctx: map } ) & {
+    id?: string,  doc?: *false & boolean,  client?: string
+    out?: top,    err?: string | boolean,  match?: map
+  }
+)
 ```
 
-Fallback without disjunction: keep all three optional (§4.1) and assert the
-exclusivity in the same build-time check script. The *value* is that the rule
-is written down once, near the data, instead of living only in `resolveArgs`.
+A green build then *proves* no entry sets two input modes at once.
 
-### 4.3 Centralise defaults via the existing `&` mechanism
+### 4.3 Centralise defaults via the existing `&:` mechanism
 
-This needs **only confident features** and can ship on its own. Extend the
-template that already exists in `test.jsonic` from "per function" to "per group"
-and "per entry":
+Extend the template that already exists in `test.jsonic` from "per function" to
+"per group", so group shape/defaults are stated once:
 
 ```jsonic
 struct: &: {
   name: key()
   set: []
-  &: {                 # for-all-children of each function = each GROUP
-    # group-level defaults / shape here
-  }
+  &: Group        # for-all-children of each function = each GROUP, typed
 }
 ```
 
-and fold `doc:false` / metadata defaults into `Entry` so individual entries stop
-repeating them. The emitted `test.json` is unchanged **iff** the defaults equal
-what the runner already assumes (`doc` absent ≡ `doc:false`, `set` absent ≡
-`[]`) — which they do.
+Per-field defaults move into `Entry` via `*value` (e.g. `doc?: *false`). The
+emitted `test.json` is unchanged **iff** each default equals what the runner
+already assumes (`doc` absent ≡ `doc:false`, `set` absent ≡ `[]`) — which it
+does, and which step 2 below verifies by diff.
 
 ### 4.4 Promote fixtures to a named, referenced slot
 
-Replace ad-hoc `data:` siblings + root-absolute paths with a declared
-`fixtures` block and relative/anchored refs:
+Replace ad-hoc `data:` siblings + root-absolute paths with the declared
+`fixtures` slot and relative refs:
 
 ```jsonic
 alts: {
   fixtures: obj0: [ { select:foo_id:true, x:1 }, … ]
   set: [
-    { in: { query:select:{foo_id:true}, obj: $fixtures.obj0 },   # or a let/alias
+    { in: { query:select:{foo_id:true}, obj: .fixtures.obj0 },  # relative ref
       out: [ … ] }
   ]
 }
 ```
 
-`Group.fixtures?: map` makes "this key is data, not tests" explicit, so doc/
-coverage tooling can skip it by type instead of by name. (Alias/relative-ref
-ergonomics — **verify**; absolute `$` refs already work as the fallback.)
+`Group.fixtures?: map` makes "this key is data, not tests" explicit by type, so
+doc/coverage tooling skips it structurally instead of name-matching `data`. The
+relative `.fixtures.obj0` replaces `$.struct.select.alts.data.obj0`. If a
+fixture must *not* appear in `test.json`, wrap it in `hide()`.
 
 ### 4.5 Resulting shape
 
 ```
 struct : Spec
-└── <function> : Function          name=key(), set defaulted
-    └── <group> : Group            { set:[...Entry], fixtures?:map, DEF?:map }
+└── <function> : Function          name=key(), set defaulted, &:Group applied
+    └── <group> : Group  (closed)   { set:[&:Entry], fixtures?:map, DEF?:map }
         ├── fixtures?              declared data slot (was ad-hoc siblings)
         ├── DEF?                   declared definitions slot (was one-off)
-        └── set : [ ...Entry ]     each element typed & defaulted
+        └── set : [ &:Entry ]      each element typed (closed) & defaulted
 ```
 
-Same three levels as today — but each level is a **named type**, defaults live
-in one place, fixtures and definitions are first-class, and malformed entries
-fail the build.
+Same three levels as today — but each level is a **named, closed type**,
+defaults live in one place, fixtures and definitions are first-class, and a
+malformed entry fails the build.
 
 
 ## 5. Migration (test.json must not move)
@@ -272,22 +283,24 @@ fail the build.
 The hard constraint: `git diff` on the regenerated `build/test/test.json` must
 be empty after each step. Recommended order, smallest-blast-radius first:
 
-1. **Add `schema.jsonic` as definitions only; don't reference it.** Regenerate
-   `test.json`; confirm zero diff (definitions emit nothing). This proves the
-   "projected-out" property on the pinned aontu version before anything depends
-   on it. *If it does* change `test.json`, stop — fall back to a standalone
-   `tools/check_testspec.py` that validates the model out-of-band and never
-   touches the build. (§4.1 fallback path.)
-2. **Adopt §4.3 defaults** (`&` group template + `Entry` metadata defaults).
-   Regenerate; confirm zero diff. This is pure cleanup and needs only confident
-   features.
-3. **Wire `set: [ ...Entry ]`** on one file (`minor.jsonic` — simplest, most
-   uniform entries) behind the verified list-template feature. Regenerate;
-   confirm zero diff; then roll across files.
-4. **Migrate fixtures (§4.4)** file by file (`select`, `transform`).
+1. **Add `schema.jsonic` with `hide()`-marked types; don't reference them yet.**
+   Regenerate `test.json`; confirm zero diff. This validates locally that
+   `hide()` excludes definitions from output on the pinned `@voxgig/model`
+   build before anything depends on it. (If the pinned version's `hide()`
+   behaves differently, fall back to a standalone `tools/check_testspec.py`
+   that unifies the model against the schema out-of-band and never touches the
+   build output.)
+2. **Apply defaults (§4.3)** — `&: Group` group template + `*value` field
+   defaults. Regenerate; confirm zero diff. Pure cleanup.
+3. **Type one file's `set` with `[ &:Entry ]` + `close()`** — start with
+   `minor.jsonic` (simplest, most uniform entries). Regenerate; confirm zero
+   diff; then roll across files one at a time. Each file's first build is where
+   a latent typo would surface as a `close()` error — fix the data, not the
+   schema.
+4. **Migrate fixtures (§4.4)** file by file (`select`, then `transform`).
    Regenerate; confirm zero diff per file.
-5. **Add the exclusivity constraint (§4.2)** last; it only *rejects* bad input,
-   so a green build proves the existing corpus already satisfies it.
+5. **Add the exclusivity disjunction (§4.2)** last; it only *rejects* bad
+   input, so a green build proves the existing corpus already satisfies it.
 
 Each step is independently revertible and gated by the same `make corpus`
 freshness check that CI already runs (`corpus-freshness` job, see
@@ -311,19 +324,21 @@ the model, keep the contract" is mechanically enforced rather than trusted.
 * **Aontu earns its keep** — the model uses unification to guard itself instead
   of being JSON behind an `@include`.
 
-## 7. Open questions to settle against the pinned aontu version
+## 7. Loose ends to confirm against the **pinned** `@voxgig/model`
 
-1. Do hidden **definitions** project out of compiled output? (Gates step 1 —
-   the whole "zero diff" strategy.)
-2. **List-element templates** `[ ...T ]`? (Gates §4.1 inline typing; §4.5 still
-   works via the check-script fallback.)
-3. **Optional fields** `field?` and **scalar type atoms** (`string`, `number`,
-   `map`, …)? (Gates per-field typing vs. defaults-only templates.)
-4. **Disjunction of structs** `A | B`? (Gates §4.2 declarative exclusivity vs.
-   a check-script assertion.)
-5. **Relative / alias references** for fixtures? (Ergonomics only; absolute `$`
-   is the fallback.)
+The language features are confirmed from upstream aontu docs; what remains is
+version- and integration-specific, all checkable in minutes during step 1:
 
-Every "no" above has a stated fallback that still reaches §4.5's typed shape;
-the proposal degrades to "schema declared + validated by a `tools/` script"
-in the worst case, which is already a strict improvement over today.
+1. **Does this aontu build's `hide()` exclude from `voxgig-model`'s emitted
+   JSON?** Gates the zero-diff strategy. Confirmed by the step-1 diff itself;
+   fallback is the out-of-band `tools/check_testspec.py`.
+2. **Does `close()` compose with the `&:` map/list templates** the way §4.1/§4.3
+   assume (template fields don't count against closedness)? If not, declare the
+   closed type at the leaf (`set: [ &:Entry ]`) and leave groups open.
+3. **`voxgig-model` import resolution for a non-spec file** — `schema.jsonic` is
+   imported for types only, not as a `struct.<fn>`. Confirm the builder doesn't
+   try to treat it as a function spec.
+
+Each has a stated fallback that still reaches §4.5's typed shape; worst case the
+proposal degrades to "schema declared in-tree + validated by a `tools/` script",
+already a strict improvement over the schema living only in `runner.ts`.

--- a/design/TESTSPEC_MODEL.md
+++ b/design/TESTSPEC_MODEL.md
@@ -1,0 +1,329 @@
+# Test Spec Model — Structure Analysis & a Type-Based Proposal
+
+**Status:** analysis / proposal (2026-06). Nothing here is implemented yet.
+This document analyses the current `build/test/*.jsonic` model and proposes a
+more coherent, *type-based* structure that uses aontu's unification features
+instead of leaving the entry schema implicit in the TypeScript runner.
+
+> Scope note. The compiled `build/test/test.json` is the behavioural contract
+> consumed by all 21 ports (see [`AGENTS.md`](../AGENTS.md)). **Any restructure
+> must leave the emitted `test.json` byte-equivalent** — otherwise it is a
+> behavioural change to every port, not a refactor. §5 (Migration) is built
+> around that constraint.
+
+
+## 1. How the model is built today
+
+The corpus is an aontu/`@voxgig/model` program, not hand-written JSON:
+
+```
+build/test/*.jsonic          # aontu source (the model)
+        │  voxgig-model test/test.jsonic         (build/package.json: "test-model")
+        ▼
+build/test/test.json         # 390 KB compiled output — the actual contract
+        │  read by typescript/test/runner.ts → resolveSpec()
+        ▼
+every port's test runner      # ts, py, go, rust, c, … all read test.json
+```
+
+`test.jsonic` is the entry point. It wires the per-function files together and
+seeds one template:
+
+```jsonic
+struct: &: {            # '&' = a template unified into EVERY child of `struct`
+  name: key()           # each function gets name = its own key
+  set: []               # …and a default empty `set`
+}
+
+struct: minor:    @"minor.jsonic"     # '@' = import/include
+struct: getpath:  @"getpath.jsonic"
+struct: validate: @"validate.jsonic"
+…
+primary: check: { DEF: { … }, basic: { set: [ … ] } }
+```
+
+So aontu *is* already doing type-ish work here — the single `struct.&`
+template is a for-all-children rule that stamps `name`/`set` onto every
+function. That mechanism is the lever this proposal pulls on; today it is
+used exactly once.
+
+
+## 2. The model has three nesting levels
+
+```
+struct
+└── <function>      e.g. getpath, merge, validate, minor.isnode …   (one per .jsonic, or one per minor fn)
+    └── <group>     e.g. basic, edge, operators, child …            ({ set:[…], + ad-hoc fixtures })
+        └── set[]   list of test ENTRIES                            (the leaf units)
+```
+
+* **Function** — one file per public function (`getpath.jsonic`, `merge.jsonic`,
+  …), except `minor.jsonic` which packs ~30 small functions (`isnode`, `ismap`,
+  `clone`, `slice`, …) as siblings.
+* **Group** — a named bucket of entries (`basic`, `relative`, `handler`,
+  `operators`, `child`, `exact`, …). A group is `{ set: [...] }`, sometimes with
+  extra sibling keys used as **fixtures** (see §3.3) and optionally a `DEF`
+  block (see §3.4).
+* **Entry** — the leaf. A single map describing one call: inputs, expected
+  output, and metadata.
+
+
+## 3. The entry "type" exists — but only in the runner
+
+There is no declared schema for an entry anywhere in the model. Its shape is
+defined *operationally* by `typescript/test/runner.ts` (`resolveArgs`,
+`checkResult`, `handleError`, `resolveEntry`). Reverse-engineered, an entry is:
+
+| Field    | Role | Notes |
+|----------|------|-------|
+| `in`     | input (single arg) | cloned, passed as the sole argument — the common case (1319 uses) |
+| `args`   | input (arg vector) | explicit positional args; mutually exclusive with `in`/`ctx` (15 uses) |
+| `ctx`    | input (context map) | wrapped via `makeContext`, gets `client`/`utility` attached (2 uses) |
+| `out`    | expectation | deep-equal against result; `null` → `__NULL__` sentinel (1192 uses) |
+| `err`    | expectation | `true` = any error, or string = substring/`/regex/` match of message (59 uses) |
+| `match`  | expectation | structural matcher: regex strings, `__UNDEF__`, `__EXISTS__` (15 uses) |
+| `id`     | metadata | doc anchor, format `"<fn>/<group>#<label>"` — consumed by `tools/gen_doc_examples.py` (44 uses) |
+| `doc`    | metadata | `true` ⇒ extract as a documentation example (39 uses) |
+| `client` | routing | names a client from the group's `DEF.client` (2 uses) |
+
+Internal-only fields the runner *adds* at runtime (`res`, `thrown`, `ctx`
+rebinding) are not part of the source model.
+
+### 3.1 Problem: the schema is invisible to aontu
+
+Because nothing declares the entry type, **aontu cannot validate it**. A typo
+(`otu:` for `out:`, `inn:` for `in:`) compiles cleanly and the entry silently
+asserts nothing — the runner just sees `out === undefined`. The model has all
+of aontu's unification machinery available and uses none of it to guard its own
+shape.
+
+### 3.2 Problem: mutually-exclusive fields are unmodelled
+
+`in` / `args` / `ctx` are three input modes; `out` / `err` / `match` are
+expectation modes. The runner resolves them by precedence, but the model never
+states the constraint, so `{ in:…, args:… }` or `{ out:…, err:… }` are
+expressible nonsense.
+
+### 3.3 Problem: fixtures are ad-hoc siblings reached by absolute paths
+
+Shared data lives as extra keys *inside* a group, next to `set`, and is
+referenced by long absolute `$` paths:
+
+```jsonic
+alts: {
+  data: obj0: [ { select:foo_id:true, x:1 }, … ]       # fixture, sibling of set
+  set: [
+    { in: { query:select:{foo_id:true}, obj: $.struct.select.alts.data.obj0 },
+      out: [ … ] }
+  ]
+}
+```
+
+`$.struct.select.alts.data.obj0` repeats the entire path from the root. There is
+no convention marking `data` as "fixture, not a test group", so tooling that
+walks groups must special-case it.
+
+### 3.4 Problem: `DEF` is a one-off
+
+`primary.check.DEF.client` is the only `DEF` in the corpus. It is a
+group-scoped definitions block the runner reads (`resolveClients`). Its
+existence is fine; that it is undocumented and unique makes it look like an
+accident rather than a designed slot.
+
+### 3.5 Net: aontu is used as a glorified `#include`
+
+Of aontu's features, the corpus uses only `@` (import), one `&` template,
+`$` absolute refs, and `key()`. Everything else is literal JSON. (Note: the
+`` `$STRING` ``/`` `$COPY` `` backtick tokens scattered through `validate.jsonic`
+and `transform.jsonic` are **struct's own** by-example sentinels — string
+*payloads* under test — not aontu syntax. Easy to conflate; they are data.)
+
+
+## 4. Proposal: declare the types, let unification enforce them
+
+The goal is a model where the entry/group/spec shapes are **declared once as
+aontu types** and unified onto the data, so that (a) malformed entries fail at
+build time, (b) defaults are centralised, and (c) the structure documents
+itself. Below, "confident" = demonstrated in this repo; "verify" = standard
+unification-language features to confirm against the pinned `@voxgig/model`
+/ aontu version before relying on them, each with a fallback that needs only
+the confident set.
+
+### 4.1 A shared schema unit
+
+Add one `build/test/schema.jsonic`, imported by `test.jsonic`, holding hidden
+**definitions** (names that unify into the data but are *projected out* of the
+emitted JSON — the property that keeps `test.json` byte-equivalent):
+
+```jsonic
+# schema.jsonic — types only; emits nothing on its own.
+
+# An Entry: one call under test.
+Entry: {
+  # metadata
+  id?:     string
+  doc?:    boolean
+
+  # input mode — exactly one of in | args | ctx
+  in?:     top
+  args?:   list
+  ctx?:    map
+
+  # expectation mode — at least one of out | err | match
+  out?:    top
+  err?:    string | boolean
+  match?:  map
+
+  # routing
+  client?: string
+}
+
+# A Group: a bucket of entries plus optional definitions/fixtures.
+Group: {
+  set:   [ ...Entry ]      # every element unified with Entry
+  DEF?:  map
+}
+```
+
+* `?` optional fields + scalar atoms (`string`, `boolean`, `map`, `list`,
+  `top`) — **verify**. Fallback if aontu lacks `?`/atoms: drop the atoms and
+  keep `Entry` as a defaults-only template (§4.3); validation is then
+  structural (closedness) rather than per-field typed.
+* `[ ...Entry ]` list-element template (apply `Entry` to every `set` item) —
+  **verify** (this is the single highest-value feature here). Fallback: a
+  build-time check script (sibling to `tools/check_corpus_regex.py`) that
+  unifies each `set` element with `Entry` and reports failures, instead of
+  doing it inline.
+
+### 4.2 Express the exclusive input / expectation modes
+
+If aontu supports disjunction of closed structs (**verify**), the
+"exactly-one-input" rule becomes declarative:
+
+```jsonic
+Entry: ({ in: top } | { args: list } | { ctx: map }) & {
+  id?: string,  doc?: boolean,  client?: string
+  out?: top,    err?: string|boolean,  match?: map
+}
+```
+
+Fallback without disjunction: keep all three optional (§4.1) and assert the
+exclusivity in the same build-time check script. The *value* is that the rule
+is written down once, near the data, instead of living only in `resolveArgs`.
+
+### 4.3 Centralise defaults via the existing `&` mechanism
+
+This needs **only confident features** and can ship on its own. Extend the
+template that already exists in `test.jsonic` from "per function" to "per group"
+and "per entry":
+
+```jsonic
+struct: &: {
+  name: key()
+  set: []
+  &: {                 # for-all-children of each function = each GROUP
+    # group-level defaults / shape here
+  }
+}
+```
+
+and fold `doc:false` / metadata defaults into `Entry` so individual entries stop
+repeating them. The emitted `test.json` is unchanged **iff** the defaults equal
+what the runner already assumes (`doc` absent ≡ `doc:false`, `set` absent ≡
+`[]`) — which they do.
+
+### 4.4 Promote fixtures to a named, referenced slot
+
+Replace ad-hoc `data:` siblings + root-absolute paths with a declared
+`fixtures` block and relative/anchored refs:
+
+```jsonic
+alts: {
+  fixtures: obj0: [ { select:foo_id:true, x:1 }, … ]
+  set: [
+    { in: { query:select:{foo_id:true}, obj: $fixtures.obj0 },   # or a let/alias
+      out: [ … ] }
+  ]
+}
+```
+
+`Group.fixtures?: map` makes "this key is data, not tests" explicit, so doc/
+coverage tooling can skip it by type instead of by name. (Alias/relative-ref
+ergonomics — **verify**; absolute `$` refs already work as the fallback.)
+
+### 4.5 Resulting shape
+
+```
+struct : Spec
+└── <function> : Function          name=key(), set defaulted
+    └── <group> : Group            { set:[...Entry], fixtures?:map, DEF?:map }
+        ├── fixtures?              declared data slot (was ad-hoc siblings)
+        ├── DEF?                   declared definitions slot (was one-off)
+        └── set : [ ...Entry ]     each element typed & defaulted
+```
+
+Same three levels as today — but each level is a **named type**, defaults live
+in one place, fixtures and definitions are first-class, and malformed entries
+fail the build.
+
+
+## 5. Migration (test.json must not move)
+
+The hard constraint: `git diff` on the regenerated `build/test/test.json` must
+be empty after each step. Recommended order, smallest-blast-radius first:
+
+1. **Add `schema.jsonic` as definitions only; don't reference it.** Regenerate
+   `test.json`; confirm zero diff (definitions emit nothing). This proves the
+   "projected-out" property on the pinned aontu version before anything depends
+   on it. *If it does* change `test.json`, stop — fall back to a standalone
+   `tools/check_testspec.py` that validates the model out-of-band and never
+   touches the build. (§4.1 fallback path.)
+2. **Adopt §4.3 defaults** (`&` group template + `Entry` metadata defaults).
+   Regenerate; confirm zero diff. This is pure cleanup and needs only confident
+   features.
+3. **Wire `set: [ ...Entry ]`** on one file (`minor.jsonic` — simplest, most
+   uniform entries) behind the verified list-template feature. Regenerate;
+   confirm zero diff; then roll across files.
+4. **Migrate fixtures (§4.4)** file by file (`select`, `transform`).
+   Regenerate; confirm zero diff per file.
+5. **Add the exclusivity constraint (§4.2)** last; it only *rejects* bad input,
+   so a green build proves the existing corpus already satisfies it.
+
+Each step is independently revertible and gated by the same `make corpus`
+freshness check that CI already runs (`corpus-freshness` job, see
+[`DOC_EXAMPLES.md`](./DOC_EXAMPLES.md)).
+
+A `make`-level guard worth adding: regenerate `test.json` into a temp file and
+`diff` it against the committed one, failing on any difference — so "refactor
+the model, keep the contract" is mechanically enforced rather than trusted.
+
+
+## 6. What this buys
+
+* **One source of truth for the entry shape** — declared in `schema.jsonic`,
+  not reverse-engineered from `runner.ts`. New ports/tools read the type.
+* **Build-time rejection** of typoed/!malformed entries (the `otu:` class of
+  silent no-op test).
+* **Centralised defaults** — entries stop repeating `doc`, and the input/
+  expectation contract is written down once.
+* **First-class fixtures & defs** — no more root-absolute `$` paths or
+  name-special-cased `data` siblings.
+* **Aontu earns its keep** — the model uses unification to guard itself instead
+  of being JSON behind an `@include`.
+
+## 7. Open questions to settle against the pinned aontu version
+
+1. Do hidden **definitions** project out of compiled output? (Gates step 1 —
+   the whole "zero diff" strategy.)
+2. **List-element templates** `[ ...T ]`? (Gates §4.1 inline typing; §4.5 still
+   works via the check-script fallback.)
+3. **Optional fields** `field?` and **scalar type atoms** (`string`, `number`,
+   `map`, …)? (Gates per-field typing vs. defaults-only templates.)
+4. **Disjunction of structs** `A | B`? (Gates §4.2 declarative exclusivity vs.
+   a check-script assertion.)
+5. **Relative / alias references** for fixtures? (Ergonomics only; absolute `$`
+   is the fallback.)
+
+Every "no" above has a stated fallback that still reaches §4.5's typed shape;
+the proposal degrades to "schema declared + validated by a `tools/` script"
+in the worst case, which is already a strict improvement over today.

--- a/design/TESTSPEC_MODEL.md
+++ b/design/TESTSPEC_MODEL.md
@@ -166,31 +166,35 @@ The aontu features used below are confirmed from
 
 The two in bold are what make this both safe and worthwhile: `hide()` keeps the
 schema out of the compiled `test.json` (so the contract stays byte-equivalent),
-and `close()` is what actually rejects a typoed field.
+and `close()` is what catches a typoed *field name* — without forbidding any
+*combination* of the known fields (§4.2).
 
-### 4.1 A shared, hidden schema unit
+### 4.1 A shared, hidden, adaptive base type
 
-Add one `build/test/schema.jsonic`, imported by `test.jsonic`, defining the
-types under a `hide()`-marked block so they participate in unification but emit
-nothing:
+Add one `build/test/schema.jsonic`, imported by `test.jsonic`, defining the base
+`Entry` under a `hide()`-marked block so it contributes constraints but emits
+nothing. Every field is **optional with a default** — the type *adapts* to
+whichever fields an entry supplies rather than demanding a fixed shape:
 
 ```jsonic
 # schema.jsonic — hidden definitions; contribute constraints, emit no JSON.
 
+# Adaptive base: all fields optional, all defaulted. An entry is whatever
+# subset of these it sets; the type adds constraints/defaults, never excludes.
 Entry: close({
-  # metadata (optional, defaulted)
+  # metadata
   id?:     string
   doc?:    *false & boolean
 
-  # input mode — exactly one of in | args | ctx (see §4.2)
-  in?:     top
-  args?:   list
-  ctx?:    map
+  # inputs — any of in | args | ctx (the runner's precedence picks one)
+  in?:     *top
+  args?:   *[] & list
+  ctx?:    *{} & map
 
-  # expectation mode — at least one of out | err | match
-  out?:    top
-  err?:    string | boolean
-  match?:  map
+  # expectations — any of out | err | match
+  out?:    *top
+  err?:    *false & (string | boolean)
+  match?:  *{} & map
 
   # routing
   client?: string
@@ -204,25 +208,38 @@ Group: close({
 ```
 
 `close(...)` makes `{ otu: 42 }` a **build error** (unknown field in a closed
-struct) instead of a silent no-op test. `[ &:Entry ]` is aontu's list-template
-form: the leading `&:Entry` is consumed (not emitted) and unified into every
-real element — exactly the high-value guarantee the model lacks today.
+struct) — but `{ in:1, out:2, id:'x' }` and `{ ctx:{…}, match:{…} }` are both
+fine, because closedness is about the *vocabulary of field names*, not which of
+them co-occur. `[ &:Entry ]` is aontu's list-template form: the leading
+`&:Entry` is consumed (not emitted) and unified into every real element.
 
-### 4.2 Express the exclusive input / expectation modes
+### 4.2 Adaptive entries, not mutually-exclusive modes
 
-Disjunction of closed structs makes the "exactly-one-input" rule — which today
-lives only in `resolveArgs`' precedence ladder — declarative:
+The earlier draft modelled inputs as a closed disjunction
+`({in} | {args} | {ctx})` so a build would *prove* "exactly one input mode."
+That is the wrong tool here, for two reasons:
 
-```jsonic
-Entry: close(
-  ( { in: top } | { args: list } | { ctx: map } ) & {
-    id?: string,  doc?: *false & boolean,  client?: string
-    out?: top,    err?: string | boolean,  match?: map
-  }
-)
-```
+1. **It doesn't match the runner.** `resolveArgs` does not reject
+   `{ in, args }` — it applies a precedence (`ctx` → `args` → `in`). A schema
+   that forbids what the runtime quietly tolerates is a second, conflicting
+   source of truth.
+2. **It fights unification.** Aontu has no conditionals, no field
+   interdependence, and no comprehensions (confirmed in
+   `reference-language.md`); its model is *monotonic, additive* unification.
+   Disjunction of closed structs is brittle under that model — adding any
+   shared field (a new `id`, a `doc` flag) must be threaded into every arm, and
+   a mistake silently changes which arm an entry selects.
 
-A green build then *proves* no entry sets two input modes at once.
+So the entry is **adaptive**: one open-ended-but-closed-on-names base (§4.1)
+whose fields are all optional and `*`-defaulted. Presence of a field *adds* its
+constraint; absence *falls back* to the default. Nothing is excluded. This is
+exactly the grain of aontu — defaults via `*`/`pref()`, refinement via `&`,
+generalisation via `super()` — and it mirrors the runner instead of contradicting
+it.
+
+The positive expression of structure then comes from **refinement, not
+exclusion**: each function adapts the base `Entry` to its own input/output shape
+by unifying a refinement through the `&:` template (§4.3) — see §4.3.1.
 
 ### 4.3 Centralise defaults via the existing `&:` mechanism
 
@@ -241,6 +258,43 @@ Per-field defaults move into `Entry` via `*value` (e.g. `doc?: *false`). The
 emitted `test.json` is unchanged **iff** each default equals what the runner
 already assumes (`doc` absent ≡ `doc:false`, `set` absent ≡ `[]`) — which it
 does, and which step 2 below verifies by diff.
+
+#### 4.3.1 Per-function adaptation — the structure that earns the keep
+
+Today `in`/`out` are `top`: the model says nothing about what a `getpath` input
+or a `validate` input *looks like*. The adaptive lever is to let each function
+**refine** the base `Entry` through the same `&:` template, so the entry type
+adapts to the function under test:
+
+```jsonic
+# in getpath.jsonic — refine every entry of every getpath group
+struct: getpath: &: &: {           # each group → each entry
+  in?:  { path?: string | list,  store?: top }
+  out?: top
+}
+
+# in validate.jsonic
+struct: validate: &: &: {
+  in?:  { data?: top,  spec?: top }
+}
+
+# in merge.jsonic — merge takes a single list argument
+struct: merge: &: &: {
+  in?:  list
+}
+```
+
+Each refinement is unified *onto* the shared `Entry` (it never replaces it), so
+metadata/expectation fields and their defaults are inherited while the
+function-specific input shape is layered on. A `getpath` entry that writes
+`in:{ pth:'a.b' }` now fails the build (if the inner shape is `close()`d),
+catching the field-level typo the base type alone can't see. This is "adaptive
+structure" in the aontu idiom: a base type generalises, per-function templates
+specialise, and unification composes the two — no disjunction, no exclusion.
+
+`minor.jsonic` (many functions per file) refines per sibling rather than per
+file: `struct: minor: isnode: &: { in?: top, out?: boolean }`, etc., or leaves
+the base as-is where inputs are genuinely heterogeneous.
 
 ### 4.4 Promote fixtures to a named, referenced slot
 
@@ -266,16 +320,17 @@ fixture must *not* appear in `test.json`, wrap it in `hide()`.
 
 ```
 struct : Spec
-└── <function> : Function          name=key(), set defaulted, &:Group applied
-    └── <group> : Group  (closed)   { set:[&:Entry], fixtures?:map, DEF?:map }
+└── <function> : Function          name=key(); refines Entry → function's in/out shape (§4.3.1)
+    └── <group> : Group  (closed)   { set:[&:Entry'], fixtures?:map, DEF?:map }
         ├── fixtures?              declared data slot (was ad-hoc siblings)
         ├── DEF?                   declared definitions slot (was one-off)
-        └── set : [ &:Entry ]      each element typed (closed) & defaulted
+        └── set : [ &:Entry' ]     Entry' = base Entry & the function's refinement
 ```
 
-Same three levels as today — but each level is a **named, closed type**,
-defaults live in one place, fixtures and definitions are first-class, and a
-malformed entry fails the build.
+Same three levels as today — but each level is a **named type**, defaults live
+in one place, fixtures and definitions are first-class, and the entry type is
+**adaptive**: a closed-on-names base that each function specialises by
+unification (`Entry'`), never a disjunction that forbids field combinations.
 
 
 ## 5. Migration (test.json must not move)
@@ -299,8 +354,11 @@ be empty after each step. Recommended order, smallest-blast-radius first:
    schema.
 4. **Migrate fixtures (§4.4)** file by file (`select`, then `transform`).
    Regenerate; confirm zero diff per file.
-5. **Add the exclusivity disjunction (§4.2)** last; it only *rejects* bad
-   input, so a green build proves the existing corpus already satisfies it.
+5. **Layer per-function refinements (§4.3.1)** last, one function at a time —
+   `struct: getpath: &: &: { in?: {…} }`, etc. These only *add* constraints to
+   already-valid data, so a green build proves each function's entries already
+   fit their declared input/output shape; the first build per function is where
+   a stray inner typo (`pth:` for `path:`) surfaces.
 
 Each step is independently revertible and gated by the same `make corpus`
 freshness check that CI already runs (`corpus-freshness` job, see
@@ -315,14 +373,18 @@ the model, keep the contract" is mechanically enforced rather than trusted.
 
 * **One source of truth for the entry shape** — declared in `schema.jsonic`,
   not reverse-engineered from `runner.ts`. New ports/tools read the type.
-* **Build-time rejection** of typoed/!malformed entries (the `otu:` class of
-  silent no-op test).
-* **Centralised defaults** — entries stop repeating `doc`, and the input/
-  expectation contract is written down once.
+* **Build-time rejection** of typoed field names (the `otu:`/`pth:` class of
+  silent no-op test) via `close()` — at both the entry and per-function level.
+* **Adaptive, not exclusive** — the entry type *refines* per function instead of
+  forbidding field combinations, so it tracks the runner's precedence semantics
+  rather than contradicting them, and stays robust under aontu's additive
+  unification (no arms to re-thread when a shared field is added).
+* **Centralised defaults** — entries stop repeating `doc`; defaults live once in
+  the base type.
 * **First-class fixtures & defs** — no more root-absolute `$` paths or
   name-special-cased `data` siblings.
-* **Aontu earns its keep** — the model uses unification to guard itself instead
-  of being JSON behind an `@include`.
+* **Aontu earns its keep** — the model uses unification (base + `&:` refinement
+  + `*` defaults) to guard itself instead of being JSON behind an `@include`.
 
 ## 7. Loose ends to confirm against the **pinned** `@voxgig/model`
 
@@ -332,9 +394,13 @@ version- and integration-specific, all checkable in minutes during step 1:
 1. **Does this aontu build's `hide()` exclude from `voxgig-model`'s emitted
    JSON?** Gates the zero-diff strategy. Confirmed by the step-1 diff itself;
    fallback is the out-of-band `tools/check_testspec.py`.
-2. **Does `close()` compose with the `&:` map/list templates** the way §4.1/§4.3
-   assume (template fields don't count against closedness)? If not, declare the
-   closed type at the leaf (`set: [ &:Entry ]`) and leave groups open.
+2. **Does `close()` compose with the `&:` map/list templates and with
+   refinement** the way §4.1/§4.3.1 assume — i.e. unifying a per-function
+   refinement *into* a closed base adds the refinement's fields rather than
+   tripping closedness? This is the crux of the adaptive design. If aontu treats
+   `close()` as final (no later additions), the fix is to close *after*
+   refinement: keep the base and refinements open, and `close()` the composed
+   `Entry'` at the leaf where the `&:Entry` list template is applied.
 3. **`voxgig-model` import resolution for a non-spec file** — `schema.jsonic` is
    imported for types only, not as a `struct.<fn>`. Confirm the builder doesn't
    try to treat it as a function spec.

--- a/design/TESTSPEC_MODEL.md
+++ b/design/TESTSPEC_MODEL.md
@@ -146,6 +146,11 @@ aontu types** and unified onto the data, so that (a) malformed entries fail at
 build time, (b) defaults are centralised, and (c) the structure documents
 itself.
 
+> The complete structure as runnable-shaped code is in
+> [`testspec-schema.jsonic`](./testspec-schema.jsonic) — base types, wiring,
+> per-function refinements, a worked entry, and the fixtures slot. The sections
+> below explain it piece by piece.
+
 The aontu features used below are confirmed from
 [`rjrodger/aontu`](https://github.com/rjrodger/aontu) `docs/reference-language.md`:
 

--- a/design/testspec-schema.jsonic
+++ b/design/testspec-schema.jsonic
@@ -1,0 +1,178 @@
+# testspec-schema.jsonic — REFERENCE DESIGN ARTIFACT (not wired into the build)
+#
+# Companion to design/TESTSPEC_MODEL.md. Expresses the proposed type-based,
+# *adaptive* structure for the build/test corpus in concrete aontu. It is a
+# single readable file here; in the real layout sections 1–5 live in the files
+# named in their headers.
+#
+# [VERIFY] tags mark the two pinned-@voxgig/model behaviours from §7 — both are
+# caught by the migration's zero-diff check, both have a stated fallback.
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. BASE TYPES                                                  (schema.jsonic)
+#    Schema marks (type()): constrain via unification, are not emitted as data.
+#    [VERIFY] that type()-marked top-level defs don't surface in test.json;
+#    if they do, wrap in hide() — they still unify, just never emit.
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Adaptive base entry. Every field is optional and *-defaulted: an entry is
+# whatever subset of these it sets — the type ADDS constraints/defaults, it
+# never excludes a combination. close() restricts the NAME vocabulary only, so
+# a typo (otu:, pth:) is a build error while any mix of valid fields is fine.
+Entry: type(close({
+
+  # ── metadata ──
+  id?:     string            # doc anchor, "<fn>/<group>#<label>"
+  doc?:    *false & boolean  # extract this entry as a documentation example?
+
+  # ── inputs (the runner applies a precedence: ctx → args → in) ──
+  in?:     *top              # single argument, cloned before the call
+  args?:   list              # explicit positional argument vector
+  ctx?:    map               # context-map invocation (makeContext)
+
+  # ── expectations ──
+  out?:    *top              # deep-equal expected result
+  err?:    string | boolean  # true = any error, or substring / /regex/ of message
+  match?:  map               # structural matcher (regex, __UNDEF__, __EXISTS__)
+
+  # ── routing ──
+  client?: string            # named client from the group's DEF.client
+}))
+
+
+# A group: a bucket of entries, plus optional shared data and definitions.
+Group: type(close({
+  set:       [ &:Entry ]     # &: list template — Entry unified into every element
+  fixtures?: map             # shared data, referenced by .fixtures.<name>
+  DEF?:      map             # group-scoped definitions (e.g. client configs)
+}))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. WIRING                                                        (test.jsonic)
+#    Import the schema, then stamp Group onto every group of every function.
+# ═══════════════════════════════════════════════════════════════════════════
+
+@"schema.jsonic"             # brings Entry / Group into scope (emit nothing)
+
+struct: &: {                 # '&:' applies to EVERY child of struct = each function
+  name: key()                # function name = its own key      (existing behaviour)
+  &: Group                   # each function's children = each GROUP, typed as Group
+}
+
+struct: minor:    @"minor.jsonic"
+struct: getpath:  @"getpath.jsonic"
+struct: inject:   @"inject.jsonic"
+struct: merge:    @"merge.jsonic"
+struct: transform:@"transform.jsonic"
+struct: walk:     @"walk.jsonic"
+struct: validate: @"validate.jsonic"
+struct: select:   @"select.jsonic"
+struct: sentinels:@"sentinels.jsonic"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. PER-FUNCTION ADAPTATION                                  (top of <fn>.jsonic)
+#    Each function REFINES the base Entry to its own input/output shape by
+#    unifying through the &: template. Refinement is additive — it layers onto
+#    Entry, never replaces it; metadata/expectation fields + defaults are
+#    inherited. The inner close() then guards the function's own field names.
+# ═══════════════════════════════════════════════════════════════════════════
+
+# getpath.jsonic — path lookup into a store
+struct: getpath: &: &: {                 # each group → each entry
+  in?:  close({ path?: string | list,  store?: top })
+  out?: *top
+}
+
+# validate.jsonic — by-example validation: data checked against spec
+struct: validate: &: &: {
+  in?:  close({ data?: top,  spec?: top })
+}
+
+# transform.jsonic — by-example transform: data shaped by spec
+struct: transform: &: &: {
+  in?:  close({ data?: top,  spec?: top,  modify?: top })
+}
+
+# merge.jsonic — deep-merge a single list of objects
+struct: merge: &: &: {
+  in?:  list
+}
+
+# inject.jsonic — store-driven value injection
+struct: inject: &: &: {
+  in?:  close({ val?: top,  store?: top })
+}
+
+# select.jsonic — query a collection (uses fixtures, §5)
+struct: select: &: &: {
+  in?:  close({ query?: top,  obj?: top })
+}
+
+# walk.jsonic — walk a single structure (callback-shaped; input stays open)
+struct: walk: &: &: {
+  in?:  top
+}
+
+# minor.jsonic — many small functions; refine per sibling, not per file:
+struct: minor: isnode: &: { in?: *top,  out?: boolean }
+struct: minor: ismap:  &: { in?: *top,  out?: boolean }
+struct: minor: clone:  &: { in?: *top,  out?: top }
+# … heterogeneous helpers (slice, pad, …) keep the base Entry unrefined.
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 4. HOW ONE ENTRY ADAPTS        Entry' = Entry & getpath-refinement (§3)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Source data (UNCHANGED — this is exactly today's corpus entry):
+#
+#   { id:'getpath/basic#deep', doc:true,
+#     in:{ path:'a.b.c', store:{a:{b:{c:42}}} }, out:42 }
+#
+# Effective type the build unifies it against:
+#
+#   close({
+#     id?:   string                                  → 'getpath/basic#deep'
+#     doc?:  *false & boolean                         → true     (overrides default)
+#     in?:   close({ path?: string|list, store?: top })
+#                                                     → { path:'a.b.c', store:{…} }
+#     out?:  *top                                     → 42
+#     args? ctx? err? match? client?  (all unset)     → dropped (optional, [VERIFY])
+#   })
+#
+# Typo guard in action (both impossible to express today):
+#
+#   { in:{ pth:'a.b.c' }, out:42 }   → BUILD ERROR: "pth" not allowed in closed in?
+#   { otu:42 }                       → BUILD ERROR: "otu" not allowed in closed Entry
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 5. FIXTURES AS A TYPED SLOT                            (select.jsonic, alts group)
+# ═══════════════════════════════════════════════════════════════════════════
+
+alts: {
+  fixtures: {
+    obj0: [ { select:{foo_id:true}, x:1 }, { select:{bar_id:true}, x:2 } ]
+  }
+  set: [
+    { in:  { query:{ select:{ foo_id:true } },  obj: .fixtures.obj0 }   # relative ref
+      out: [ { '$KEY':0, select:{foo_id:true}, x:1 } ] }
+  ]
+}
+# was:  obj: $.struct.select.alts.data.obj0     (root-absolute path, repeated in full)
+# now:  obj: .fixtures.obj0                      (relative; fixtures typed, not a fake group)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# NOTE on defaults & zero-diff ([VERIFY], §7 / migration step 2)
+#   '*' defaults (doc?:*false, in?:*top) are for validation/documentation
+#   semantics. For test.json to stay byte-equivalent, an unset optional field
+#   must NOT materialise its default into output. aontu drops unresolved
+#   optionals — confirm the '*' default doesn't count as "resolved". If it
+#   does, either (a) drop the '*' from optionals and keep them pure
+#   constraints, or (b) accept a one-time normalisation of test.json (the
+#   runner already treats absent ≡ default, so every port still passes).
+# ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Reverse-engineers the implicit entry schema currently defined only in
typescript/test/runner.ts, documents the three-level
struct/function/group/set model, and proposes declaring Entry/Group/Spec
as aontu types so unification guards the corpus shape, centralises
defaults, and makes fixtures/DEF first-class. Includes a migration plan
gated on keeping the compiled build/test/test.json byte-equivalent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fn6v25EtY7Kss941hkMhrn